### PR TITLE
Voting module!

### DIFF
--- a/backend/api/controllers/PromptController.js
+++ b/backend/api/controllers/PromptController.js
@@ -74,3 +74,69 @@ exports.delete_a_prompt = function(req, res) {
     }
   );
 };
+
+exports.add_vote_idea = function(req, res) {
+  Prompt.findById(req.params.promptId, function(err, prompt) {
+    if (err) {
+      res.send(err);
+    }
+
+    var ideaId = req.params.ideaId;
+    if (!prompt.votes) {
+      prompt.votes = {};
+    }
+    if (!prompt.votes[ideaId]) {
+      prompt.votes.set(ideaId, []);
+    }
+
+    var ideaVotes = prompt.votes.get(ideaId);
+    var index = ideaVotes.indexOf(req.body.user_id);
+    var containsVote = index > 0;
+
+    if (containsVote) {
+      ideaVotes.splice(index, 1, req.body);
+    } else {
+      ideaVotes.push(req.body);
+    }
+    prompt.votes.set(ideaId, ideaVotes);
+
+    prompt.save(function(err) {
+      if (err) {
+        res.send(err);
+      }
+      res.json(prompt);
+    });
+  }).populate("ideas");
+};
+
+exports.delete_vote_idea = function(req, res) {
+  Prompt.findById(req.params.promptId, function(err, prompt) {
+    if (err) {
+      res.send(err);
+    }
+
+    var ideaId = req.params.ideaId;
+    if (!prompt.votes) {
+      prompt.votes = {};
+    }
+    if (!prompt.votes[ideaId]) {
+      prompt.votes.set(ideaId, []);
+    }
+
+    var ideaVotes = prompt.votes.get(ideaId);
+    var index = ideaVotes.indexOf(req.body.user_id);
+    var containsVote = index > 0;
+
+    if (containsVote) {
+      ideaVotes.splice(index, 1);
+    }
+    prompt.votes.set(ideaId, ideaVotes);
+
+    prompt.save(function(err) {
+      if (err) {
+        res.send(err);
+      }
+      res.json(prompt);
+    });
+  }).populate("ideas");
+};

--- a/backend/api/controllers/PromptController.js
+++ b/backend/api/controllers/PromptController.js
@@ -1,67 +1,76 @@
-var mongoose = require('mongoose'),
-  Prompt = mongoose.model('Prompts'),
-  Project = mongoose.model('Projects');
+var mongoose = require("mongoose"),
+  Prompt = mongoose.model("Prompts"),
+  Project = mongoose.model("Projects");
 
 exports.list_all_prompts = function(req, res) {
-  console.log('rsds');
+  console.log("rsds");
   Prompt.find({}, function(err, prompt) {
-    console.log('rasasds');
-    if (err)
-      res.send(err);
+    console.log("rasasds");
+    if (err) res.send(err);
     res.json(prompt);
   });
 };
 
 exports.create_a_prompt = function(req, res) {
-if(req.body._id !=null){
-    Prompt.findOneAndUpdate({_id: req.body._id}, req.body, {new: true}, function(err, prompt) {
-      if (err)
-        res.send(err);
+  if (req.body._id != null) {
+    Prompt.findOneAndUpdate(
+      { _id: req.body._id },
+      req.body,
+      { new: true },
+      function(err, prompt) {
+        if (err) res.send(err);
+        res.json(prompt);
+      }
+    );
+  } else {
+    var new_prompt = new Prompt(req.body);
+    new_prompt.save(function(err, prompt) {
+      console.log("prid" + prompt._id);
+      console.log("prid" + req.body.project);
+      if (err) res.send(err);
+      Project.findOneAndUpdate(
+        { _id: req.body.project },
+        { $push: { prompts: prompt._id } },
+        { new: true },
+        function(err, project) {
+          console.log(err);
+          console.log("pro" + project);
+        }
+      );
       res.json(prompt);
     });
   }
-  else{
-    var new_prompt = new Prompt(req.body);
-    new_prompt.save(function(err, prompt) {
-      console.log("prid"+prompt._id);
-      console.log("prid"+req.body.project);
-      if (err)
-        res.send(err);
-      Project.findOneAndUpdate({_id:req.body.project},{$push: {prompts: prompt._id}},{new: true},function(err, project){
-        console.log(err);
-        console.log("pro"+project);
-      });
-      res.json(prompt);
-    });
-}
 };
-
 
 exports.read_a_prompt = function(req, res) {
   console.log(req.params.promptId);
   Prompt.findById(req.params.promptId, function(err, prompt) {
-    if (err)
-      res.send(err);
+    if (err) res.send(err);
     res.json(prompt);
-  }).populate('ideas');
+  }).populate("ideas");
 };
-
 
 exports.update_a_prompt = function(req, res) {
-  Prompt.findOneAndUpdate({_id: req.params.promptId}, req.body, {new: true}, function(err, prompt) {
-    if (err)
-      res.send(err);
-    res.json(prompt);
-  });
+  Prompt.findOneAndUpdate(
+    { _id: req.params.promptId },
+    req.body,
+    { new: true },
+    function(err, prompt) {
+      console.log(prompt);
+      if (err) res.send(err);
+      res.json(prompt);
+    }
+  );
 };
 
-
 exports.delete_a_prompt = function(req, res) {
-  Prompt.remove({
-    _id: req.params.promptId
-  }, function(err, prompt) {
-    if (err)
-      res.send(err);
-    res.json({ message: 'prompt successfully deleted' });
-  });
+  Prompt.remove(
+    {
+      _id: req.params.promptId
+    },
+    function(err, prompt) {
+      if (err) res.send(err);
+      res.json({ message: "prompt successfully deleted" });
+    }
+  );
 };

--- a/backend/api/models/prompt.js
+++ b/backend/api/models/prompt.js
@@ -23,13 +23,15 @@ var promptSchema = new Schema({
 
   votes: {
     type: Map,
-    of: {
-      user_id: String,
-      position: {
-        x: Number,
-        y: Number
+    of: [
+      {
+        user_id: String,
+        position: {
+          x: Number,
+          y: Number
+        }
       }
-    }
+    ]
   }
 });
 

--- a/backend/api/models/prompt.js
+++ b/backend/api/models/prompt.js
@@ -1,25 +1,36 @@
-var mongoose = require('mongoose');
+var mongoose = require("mongoose");
 var Schema = mongoose.Schema;
 
 var promptSchema = new Schema({
   text: {
-    type: String,
+    type: String
   },
 
-  author: {type: mongoose.Schema.Types.ObjectId, ref: 'Users'},
+  author: { type: mongoose.Schema.Types.ObjectId, ref: "Users" },
 
-  project: {type: String},
+  project: { type: String },
 
-  ideas: [{type: mongoose.Schema.Types.ObjectId, ref: 'Ideas'}],
+  ideas: [{ type: mongoose.Schema.Types.ObjectId, ref: "Ideas" }],
 
-  values: [{type:{type:Number}, text: {type: String}}],
+  values: [{ type: { type: Number }, text: { type: String } }],
 
-  favorite_ideas: [{type: String}],
+  favorite_ideas: [{ type: String }],
 
   Created_date: {
     type: Date,
     default: Date.now
+  },
+
+  votes: {
+    type: Map,
+    of: {
+      user_id: String,
+      position: {
+        x: Number,
+        y: Number
+      }
+    }
   }
 });
 
-module.exports = mongoose.model('Prompts', promptSchema);
+module.exports = mongoose.model("Prompts", promptSchema);

--- a/backend/api/routes/PromptRoutes.js
+++ b/backend/api/routes/PromptRoutes.js
@@ -1,14 +1,20 @@
 module.exports = function(app) {
-  var prompt = require('../controllers/PromptController');
+  var prompt = require("../controllers/PromptController");
 
   // prompt Routes
-  app.route('/prompts')
+  app
+    .route("/prompts")
     .get(prompt.list_all_prompts)
     .post(prompt.create_a_prompt);
 
-
-  app.route('/prompts/:promptId')
+  app
+    .route("/prompts/:promptId")
     .get(prompt.read_a_prompt)
     .put(prompt.update_a_prompt)
     .delete(prompt.delete_a_prompt);
+
+  app
+    .route("/prompts/:promptId/ideas/:ideaId/vote")
+    .put(prompt.add_vote_idea)
+    .delete(prompt.delete_vote_idea);
 };

--- a/client/client/package-lock.json
+++ b/client/client/package-lock.json
@@ -2984,22 +2984,26 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+              "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
               "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "optional": true
             },
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+              "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
               "optional": true,
               "requires": {
                 "delegates": "^1.0.0",
@@ -3008,12 +3012,14 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
@@ -3022,32 +3028,38 @@
             },
             "chownr": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+              "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
               "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "optional": true
             },
             "debug": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
               "optional": true,
               "requires": {
                 "ms": "^2.1.1"
@@ -3055,22 +3067,26 @@
             },
             "deep-extend": {
               "version": "0.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+              "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
               "optional": true
             },
             "delegates": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+              "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
               "optional": true
             },
             "fs-minipass": {
               "version": "1.2.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+              "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
               "optional": true,
               "requires": {
                 "minipass": "^2.2.1"
@@ -3078,12 +3094,14 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "optional": true
             },
             "gauge": {
               "version": "2.7.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "optional": true,
               "requires": {
                 "aproba": "^1.0.3",
@@ -3098,7 +3116,8 @@
             },
             "glob": {
               "version": "7.1.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+              "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
               "optional": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
@@ -3111,12 +3130,14 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "optional": true
             },
             "iconv-lite": {
               "version": "0.4.24",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+              "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "optional": true,
               "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
@@ -3124,7 +3145,8 @@
             },
             "ignore-walk": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+              "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "optional": true,
               "requires": {
                 "minimatch": "^3.0.4"
@@ -3132,7 +3154,8 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "optional": true,
               "requires": {
                 "once": "^1.3.0",
@@ -3141,17 +3164,20 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "optional": true
             },
             "ini": {
               "version": "1.3.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+              "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
@@ -3159,12 +3185,14 @@
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
@@ -3172,12 +3200,14 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "optional": true
             },
             "minipass": {
               "version": "2.3.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+              "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
               "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
@@ -3186,7 +3216,8 @@
             },
             "minizlib": {
               "version": "1.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+              "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
               "optional": true,
               "requires": {
                 "minipass": "^2.2.1"
@@ -3194,7 +3225,8 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "optional": true,
               "requires": {
                 "minimist": "0.0.8"
@@ -3202,12 +3234,14 @@
             },
             "ms": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
               "optional": true
             },
             "needle": {
               "version": "2.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
+              "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
               "optional": true,
               "requires": {
                 "debug": "^4.1.0",
@@ -3217,7 +3251,8 @@
             },
             "node-pre-gyp": {
               "version": "0.12.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+              "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
               "optional": true,
               "requires": {
                 "detect-libc": "^1.0.2",
@@ -3234,7 +3269,8 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "optional": true,
               "requires": {
                 "abbrev": "1",
@@ -3243,12 +3279,14 @@
             },
             "npm-bundled": {
               "version": "1.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+              "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
               "optional": true
             },
             "npm-packlist": {
               "version": "1.4.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+              "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
               "optional": true,
               "requires": {
                 "ignore-walk": "^3.0.1",
@@ -3257,7 +3295,8 @@
             },
             "npmlog": {
               "version": "4.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "optional": true,
               "requires": {
                 "are-we-there-yet": "~1.1.2",
@@ -3268,17 +3307,20 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "optional": true,
               "requires": {
                 "wrappy": "1"
@@ -3286,17 +3328,20 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "optional": true
             },
             "osenv": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+              "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "optional": true,
               "requires": {
                 "os-homedir": "^1.0.0",
@@ -3305,17 +3350,20 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+              "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
               "optional": true
             },
             "rc": {
               "version": "1.2.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+              "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
               "optional": true,
               "requires": {
                 "deep-extend": "^0.6.0",
@@ -3326,14 +3374,16 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "optional": true
                 }
               }
             },
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "optional": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -3347,7 +3397,8 @@
             },
             "rimraf": {
               "version": "2.6.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+              "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "optional": true,
               "requires": {
                 "glob": "^7.1.3"
@@ -3355,37 +3406,44 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+              "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
               "optional": true
             },
             "sax": {
               "version": "1.2.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+              "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
               "optional": true
             },
             "semver": {
               "version": "5.7.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "optional": true
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -3395,7 +3453,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "optional": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -3403,7 +3462,8 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -3411,12 +3471,14 @@
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "optional": true
             },
             "tar": {
               "version": "4.4.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+              "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
               "optional": true,
               "requires": {
                 "chownr": "^1.1.1",
@@ -3430,12 +3492,14 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "optional": true
             },
             "wide-align": {
               "version": "1.1.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+              "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
               "optional": true,
               "requires": {
                 "string-width": "^1.0.2 || 2"
@@ -3443,12 +3507,14 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
               "optional": true
             }
           }
@@ -6926,22 +6992,26 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+              "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
               "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "optional": true
             },
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+              "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
               "optional": true,
               "requires": {
                 "delegates": "^1.0.0",
@@ -6950,12 +7020,14 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
@@ -6964,32 +7036,38 @@
             },
             "chownr": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+              "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
               "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "optional": true
             },
             "debug": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
               "optional": true,
               "requires": {
                 "ms": "^2.1.1"
@@ -6997,22 +7075,26 @@
             },
             "deep-extend": {
               "version": "0.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+              "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
               "optional": true
             },
             "delegates": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+              "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
               "optional": true
             },
             "fs-minipass": {
               "version": "1.2.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+              "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
               "optional": true,
               "requires": {
                 "minipass": "^2.2.1"
@@ -7020,12 +7102,14 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "optional": true
             },
             "gauge": {
               "version": "2.7.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "optional": true,
               "requires": {
                 "aproba": "^1.0.3",
@@ -7040,7 +7124,8 @@
             },
             "glob": {
               "version": "7.1.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+              "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
               "optional": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
@@ -7053,12 +7138,14 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "optional": true
             },
             "iconv-lite": {
               "version": "0.4.24",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+              "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "optional": true,
               "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
@@ -7066,7 +7153,8 @@
             },
             "ignore-walk": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+              "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "optional": true,
               "requires": {
                 "minimatch": "^3.0.4"
@@ -7074,7 +7162,8 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "optional": true,
               "requires": {
                 "once": "^1.3.0",
@@ -7083,17 +7172,20 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "optional": true
             },
             "ini": {
               "version": "1.3.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+              "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
@@ -7101,12 +7193,14 @@
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
@@ -7114,12 +7208,14 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "optional": true
             },
             "minipass": {
               "version": "2.3.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+              "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
               "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
@@ -7128,7 +7224,8 @@
             },
             "minizlib": {
               "version": "1.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+              "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
               "optional": true,
               "requires": {
                 "minipass": "^2.2.1"
@@ -7136,7 +7233,8 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "optional": true,
               "requires": {
                 "minimist": "0.0.8"
@@ -7144,12 +7242,14 @@
             },
             "ms": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
               "optional": true
             },
             "needle": {
               "version": "2.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
+              "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
               "optional": true,
               "requires": {
                 "debug": "^4.1.0",
@@ -7159,7 +7259,8 @@
             },
             "node-pre-gyp": {
               "version": "0.12.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+              "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
               "optional": true,
               "requires": {
                 "detect-libc": "^1.0.2",
@@ -7176,7 +7277,8 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "optional": true,
               "requires": {
                 "abbrev": "1",
@@ -7185,12 +7287,14 @@
             },
             "npm-bundled": {
               "version": "1.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+              "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
               "optional": true
             },
             "npm-packlist": {
               "version": "1.4.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+              "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
               "optional": true,
               "requires": {
                 "ignore-walk": "^3.0.1",
@@ -7199,7 +7303,8 @@
             },
             "npmlog": {
               "version": "4.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "optional": true,
               "requires": {
                 "are-we-there-yet": "~1.1.2",
@@ -7210,17 +7315,20 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "optional": true,
               "requires": {
                 "wrappy": "1"
@@ -7228,17 +7336,20 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "optional": true
             },
             "osenv": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+              "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "optional": true,
               "requires": {
                 "os-homedir": "^1.0.0",
@@ -7247,17 +7358,20 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+              "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
               "optional": true
             },
             "rc": {
               "version": "1.2.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+              "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
               "optional": true,
               "requires": {
                 "deep-extend": "^0.6.0",
@@ -7268,14 +7382,16 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "optional": true
                 }
               }
             },
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "optional": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -7289,7 +7405,8 @@
             },
             "rimraf": {
               "version": "2.6.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+              "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "optional": true,
               "requires": {
                 "glob": "^7.1.3"
@@ -7297,37 +7414,44 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+              "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
               "optional": true
             },
             "sax": {
               "version": "1.2.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+              "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
               "optional": true
             },
             "semver": {
               "version": "5.7.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "optional": true
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -7337,7 +7461,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "optional": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -7345,7 +7470,8 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -7353,12 +7479,14 @@
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "optional": true
             },
             "tar": {
               "version": "4.4.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+              "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
               "optional": true,
               "requires": {
                 "chownr": "^1.1.1",
@@ -7372,12 +7500,14 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "optional": true
             },
             "wide-align": {
               "version": "1.1.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+              "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
               "optional": true,
               "requires": {
                 "string-width": "^1.0.2 || 2"
@@ -7385,12 +7515,14 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
               "optional": true
             }
           }

--- a/client/client/package.json
+++ b/client/client/package.json
@@ -8,7 +8,7 @@
     "react-dom": "^16.6.1",
     "react-google-login": "^5.0.2",
     "react-router-dom": "^4.3.1",
-    "react-scripts": "^3.0.0",
+    "react-scripts": "3.0.0",
     "styled-components": "^4.1.3"
   },
   "scripts": {

--- a/client/client/src/App.js
+++ b/client/client/src/App.js
@@ -1,18 +1,18 @@
-import React, {Component} from 'react';
-import logo from './logo.svg';
-import './App.css';
-import {Switch, Route} from 'react-router-dom'
-import AllProjects from './components/AllProjects'
-import SingleProject from './components/SingleProject'
-import CreateNewProject from './components/CreateNewProject'
-import Header from './components/Header'
-import ValuesInput from './components/ValuesInput'
-import OpportunitiesInput from './components/OpportunitiesInput'
-import Cheatstorm from './components/Cheatstorm'
-import IdeasView from './components/IdeasView'
+import React, { Component } from "react";
+import logo from "./logo.svg";
+import "./App.css";
+import { Switch, Route } from "react-router-dom";
+import AllProjects from "./components/AllProjects";
+import SingleProject from "./components/SingleProject";
+import CreateNewProject from "./components/CreateNewProject";
+import Header from "./components/Header";
+import ValuesInput from "./components/ValuesInput";
+import OpportunitiesInput from "./components/OpportunitiesInput";
+import Cheatstorm from "./components/Cheatstorm";
+import IdeasView from "./components/IdeasView";
+import VoteView from "./components/VoteView";
 
 class App extends Component {
-
   constructor() {
     super();
   }
@@ -20,24 +20,29 @@ class App extends Component {
 
   // 7vE0EjS8fgqb-97KJonFQqCF
   render() {
-    return (<div>
-      <Header/>
-      <Switch>
-        <Route exact="exact" path='/' component={AllProjects}/>
-        <Route path='/create_new_project/' component={CreateNewProject}/>
-        <Route path='/project/:id' component={SingleProject}/>
-        <Route path='/valuesinput/:id' component={ValuesInput}/>
-        <Route path='/opportunitiesinput/:id' component={OpportunitiesInput}/>
-        <Route path='/cheatstorm/:id' component={Cheatstorm}/>
-        <Route path='/ideasview/:id' component={IdeasView}/>
-      </Switch>
-    </div>);
+    return (
+      <div>
+        <Header />
+        <Switch>
+          <Route exact path="/" component={AllProjects} />
+          <Route path="/create_new_project/" component={CreateNewProject} />
+          <Route path="/project/:id" component={SingleProject} />
+          <Route path="/valuesinput/:id" component={ValuesInput} />
+          <Route
+            path="/opportunitiesinput/:id"
+            component={OpportunitiesInput}
+          />
+          <Route path="/cheatstorm/:id" component={Cheatstorm} />
+          <Route path="/ideasview/:id" component={IdeasView} />
+          <Route path="/vote/:id" component={VoteView} />
+        </Switch>
+      </div>
+    );
   }
 
-  googleResponse = (response) => {
+  googleResponse = response => {
     console.log(response);
   };
-
 }
 
 export default App;

--- a/client/client/src/App.js
+++ b/client/client/src/App.js
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import logo from "./logo.svg";
 import "./App.css";
 import { Switch, Route } from "react-router-dom";
 import AllProjects from "./components/AllProjects";
@@ -13,9 +12,6 @@ import IdeasView from "./components/IdeasView";
 import VoteView from "./components/VoteView";
 
 class App extends Component {
-  constructor() {
-    super();
-  }
   // 747584954544-1qnj29p7cp9s9i6ind8jegnracl1tihq.apps.googleusercontent.com
 
   // 7vE0EjS8fgqb-97KJonFQqCF

--- a/client/client/src/components/Cheatstorm.js
+++ b/client/client/src/components/Cheatstorm.js
@@ -1,76 +1,74 @@
-import React, { Component } from 'react';
-import '../css/main.css';
-import LikeCard from './LikeCard'
-import WishCard from './WishCard'
-import styled from 'styled-components'
+import React, { Component } from "react";
+import "../css/main.css";
+import LikeCard from "./LikeCard";
+import WishCard from "./WishCard";
+import styled from "styled-components";
 
 const Wrapper = styled.div`
- margin: 50px auto ;
- max-width:800px;
- text-align:center;
+  margin: 50px auto;
+  max-width: 800px;
+  text-align: center;
 `;
 
 const Sticky = styled.textarea`
- margin:auto
- width: 160px;
- height: 160px;
- border-radius: 1px;
- border:none;
- background-color: ${props => props.wish? '#d4d3ff' : props.like ? '#ffe677' :'#fffc8d'};
- resize:none;
- outline:none;
- overflow:hidden;
- font-size: 15px;
+  margin: auto;
+  width: 160px;
+  height: 160px;
+  border-radius: 1px;
+  border: none;
+  background-color: ${props =>
+    props.wish ? "#d4d3ff" : props.like ? "#ffe677" : "#fffc8d"};
+  resize: none;
+  outline: none;
+  overflow: hidden;
+  font-size: 15px;
   font-weight: normal;
   font-style: normal;
   font-stretch: normal;
   line-height: 1.6;
   letter-spacing: 0.2px;
   color: #000000;
-  padding:10px;
-  margin:5px;
+  padding: 10px;
+  margin: 5px;
 `;
 
-const ValueWrapper = styled.div `
-  max-width:690px;
+const ValueWrapper = styled.div`
+  max-width: 690px;
   height: 35vh;
-  margin:auto;
-  overflow:scroll;
+  margin: auto;
+  overflow: scroll;
 `;
 
 const InputContainer = styled.div`
-width:60%;
-margin:auto;
-padding:1%;
-
+  width: 60%;
+  margin: auto;
+  padding: 1%;
 `;
 
 const Input = styled.textarea`
- margin:2%;
- padding:2%;
- width: 29%;
- height: 160px;
- border-radius: 1px;
-border: solid 1px #b9b9b9;
-background-color: #ffffff;
-resize:none;
-outline:none;
-overflow:hidden;
-font-size: 15px;
- font-weight: normal;
- font-style: normal;
- font-stretch: normal;
- line-height: 1.6;
- letter-spacing: 0.2px;
-
+  margin: 2%;
+  padding: 2%;
+  width: 29%;
+  height: 160px;
+  border-radius: 1px;
+  border: solid 1px #b9b9b9;
+  background-color: #ffffff;
+  resize: none;
+  outline: none;
+  overflow: hidden;
+  font-size: 15px;
+  font-weight: normal;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: 1.6;
+  letter-spacing: 0.2px;
 `;
 
-
 const BottomWrapper = styled.div`
-  width:690px;
+  width: 690px;
   height: 150px;
-  margin:auto;
-  position:relative;
+  margin: auto;
+  position: relative;
 `;
 
 const SubmitButton = styled.button`
@@ -82,8 +80,8 @@ const SubmitButton = styled.button`
   position: absolute;
   top: 50px;
   right: 0;
-  color:#fafafa;
-  text-transform:uppercase;
+  color: #fafafa;
+  text-transform: uppercase;
 `;
 
 const Progress = styled.p`
@@ -92,17 +90,17 @@ const Progress = styled.p`
   font-style: normal;
   font-stretch: normal;
   letter-spacing: 0.5px;
-  color: ${props => props.disabled ? '#b9b9b9' : '#000000'};
-  border: solid 3px ${props => props.disabled ? '#b9b9b9' : '#ffe74c'};
+  color: ${props => (props.disabled ? "#b9b9b9" : "#000000")};
+  border: solid 3px ${props => (props.disabled ? "#b9b9b9" : "#ffe74c")};
   width: 75px;
   height: 75px;
-  line-height:65px;
-  border-radius:100%;
-  text-align:center;
-  margin:30px;
-  margin-left:0;
-  float:left;
-  background-color: ${props => props.disabled ? '#fafafa' : 'white'};
+  line-height: 65px;
+  border-radius: 100%;
+  text-align: center;
+  margin: 30px;
+  margin-left: 0;
+  float: left;
+  background-color: ${props => (props.disabled ? "#fafafa" : "white")};
 `;
 
 const BottomText = styled.p`
@@ -113,169 +111,175 @@ const BottomText = styled.p`
   line-height: normal;
   letter-spacing: 0.2px;
   color: #000000;
-  float:left;
+  float: left;
   margin-top: 55px;
   margin-right: 70px;
-
-
 `;
 
 class Cheatstorm extends Component {
-
   constructor(props) {
-   super(props);
+    super(props);
 
-   this.state = {
-     data: null,
-     ideas:[],
-     inputs:[],
-     currentInputs:[]
-   };
+    this.state = {
+      data: null,
+      ideas: [],
+      inputs: [],
+      currentInputs: []
+    };
 
-   this.handleTextChange = this.handleTextChange.bind(this);
-   this.handleKeyPress = this.handleKeyPress.bind(this);
-   this.handleSubmit = this.handleSubmit.bind(this);
-   this.handleInputClick = this.handleInputClick.bind(this);
- }
-
-  handleInputClick(ev){
-    this.setState({currentIdeaText: this.state.currentInputs[parseInt(ev.target.id)].content.title});
+    this.handleTextChange = this.handleTextChange.bind(this);
+    this.handleKeyPress = this.handleKeyPress.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleInputClick = this.handleInputClick.bind(this);
   }
 
- handleTextChange(event){
-   var textValue = event.target.value;
-   this.setState({currentIdeaText: textValue});
-   if(textValue.trim().length<1){
-     event.target.focus();
-     event.target.setSelectionRange(0,0);
-   }
- }
-
- handleKeyPress(event){
-   if(event.key == 'Enter'){
-    this.storeCurrentValue();
-    this.setState({currentIdeaText: ""});
-    this.refreshIdeationInputs();
+  handleInputClick(ev) {
+    this.setState({
+      currentIdeaText: this.state.currentInputs[parseInt(ev.target.id)].content
+        .title
+    });
   }
- }
 
- storeCurrentValue(){
-   this.state.ideas.push(
-     {
-       prompt_id: this.props.match.params.id,
-       content:{
-         title: this.state.currentIdeaText
-       }
-     }
-   );
- }
+  handleTextChange(event) {
+    var textValue = event.target.value;
+    this.setState({ currentIdeaText: textValue });
+    if (textValue.trim().length < 1) {
+      event.target.focus();
+      event.target.setSelectionRange(0, 0);
+    }
+  }
 
- handleSubmit(event){
-   this.state.ideas.map(function(idea,i){
-     fetch('/ideas',
-       { method:'POST',
-         body: JSON.stringify(idea),
-         headers: {
-           'Accept': 'application/json, text/plain, */*',
-           'Content-Type': 'application/json',
-           'Mode' : "CORS"
-         }
-       }).then(response => response.json())
-       .then(data =>
-         {
-           console.log(data);
-         }
-       );
+  handleKeyPress(event) {
+    if (event.key == "Enter") {
+      this.storeCurrentValue();
+      this.setState({ currentIdeaText: "" });
+      this.refreshIdeationInputs();
+    }
+  }
 
-   });
-       alert("Successfully Submitted!");
-       // alert(JSON.stringify(this.state.data))
-       this.props.history.push('/project/'+this.state.data.project);
- }
+  storeCurrentValue() {
+    this.state.ideas.push({
+      prompt_id: this.props.match.params.id,
+      content: {
+        title: this.state.currentIdeaText
+      }
+    });
+  }
 
+  handleSubmit(event) {
+    this.state.ideas.map(function(idea, i) {
+      fetch("/ideas", {
+        method: "POST",
+        body: JSON.stringify(idea),
+        headers: {
+          Accept: "application/json, text/plain, */*",
+          "Content-Type": "application/json",
+          Mode: "CORS"
+        }
+      })
+        .then(response => response.json())
+        .then(data => {
+          console.log(data);
+        });
+    });
+    alert("Successfully Submitted!");
+    // alert(JSON.stringify(this.state.data))
+    this.props.history.push("/project/" + this.state.data.project);
+  }
 
+  componentDidMount() {
+    fetch("/prompts/" + this.props.match.params.id)
+      .then(response => response.json())
+      .then(data => {
+        this.setState({ data });
 
- componentDidMount() {
-   fetch('/prompts/'+this.props.match.params.id)
-     .then(response => response.json())
-     .then(data => {
-       this.setState({data});
+        fetch("/ideas/random")
+          .then(response => response.json())
+          .then(inputs => {
+            try {
+              this.setState({ inputs });
+              this.setState({
+                currentInputs: [
+                  this.state.inputs.pop(),
+                  this.state.inputs.pop(),
+                  this.state.inputs.pop()
+                ]
+              });
+            } catch (e) {}
+          })
+          .catch(function() {
+            console.log("error");
+          });
+      });
+  }
 
-       fetch('/ideas/random')
-         .then(response => response.json())
-         .then(inputs => {
-           try{
-           this.setState({inputs});
-           this.setState({currentInputs:[this.state.inputs.pop(),this.state.inputs.pop(),this.state.inputs.pop()]});
-         }catch(e){
-
-         }
-           }).catch(function() {
-        console.log("error");
-    });;
-
-   });
- }
-
- refreshIdeationInputs(){
-   if(this.state.inputs.length>3){
-     this.setState({currentInputs:[this.state.inputs.pop(),this.state.inputs.pop(),this.state.inputs.pop()]});
-     this.forceUpdate();
-   }
-   if(this.state.inputs.length<4){
-     fetch('/ideas/random')
-       .then(response => response.json())
-       .then(inputs => {
-         try{
-         this.setState({inputs});
-       }catch(e){
-       }
-     }).catch(function() {
-        console.log("error");
-    });;
-   }
- }
-
-
+  refreshIdeationInputs() {
+    if (this.state.inputs.length > 3) {
+      this.setState({
+        currentInputs: [
+          this.state.inputs.pop(),
+          this.state.inputs.pop(),
+          this.state.inputs.pop()
+        ]
+      });
+      this.forceUpdate();
+    }
+    if (this.state.inputs.length < 4) {
+      fetch("/ideas/random")
+        .then(response => response.json())
+        .then(inputs => {
+          try {
+            this.setState({ inputs });
+          } catch (e) {}
+        })
+        .catch(function() {
+          console.log("error");
+        });
+    }
+  }
 
   render() {
-    if(this.state.data != null){
+    if (this.state.data != null) {
       var prompt = this.state.data;
-    return (
-      <div>
-        <h2 className="text_center">How might we <strong>{prompt.text}</strong>?</h2>
-        <InputContainer>
-        {this.state.currentInputs.map(function(idea, i){
-          return <Input readOnly onClick={this.handleInputClick} id={i}value={idea.content.title}>
-          </Input>
-        },this)}
-        </InputContainer>
-        <Wrapper>
-          <Sticky
-            onChange={this.handleTextChange} onKeyPress={this.handleKeyPress} value={this.state.currentIdeaText}>
-          </Sticky>
-        </Wrapper>
-        <ValueWrapper>
+      return (
+        <div>
+          <h2 className="text_center">
+            How might we <strong>{prompt.text}</strong>?
+          </h2>
+          <InputContainer>
+            {this.state.currentInputs.map(function(idea, i) {
+              return (
+                <Input
+                  readOnly
+                  onClick={this.handleInputClick}
+                  id={i}
+                  value={idea.content.title}
+                />
+              );
+            }, this)}
+          </InputContainer>
+          <Wrapper>
+            <Sticky
+              onChange={this.handleTextChange}
+              onKeyPress={this.handleKeyPress}
+              value={this.state.currentIdeaText}
+            />
+          </Wrapper>
+          <ValueWrapper>
+            {this.state.ideas.map(function(idea, i) {
+              return <Sticky>{idea.content.title}</Sticky>;
+            })}
+          </ValueWrapper>
 
-          {this.state.ideas.map(function(idea, i){
-            return <Sticky>
-              {idea.content.title}
-            </Sticky>
-
-          })}
-
-        </ValueWrapper>
-
-        <BottomWrapper>
-          <Progress>{this.state.ideas.length}</Progress>
-          <BottomText>Ideas</BottomText>
-          <SubmitButton onClick={this.handleSubmit}>Submit</SubmitButton>
-        </BottomWrapper>
-
-      </div>
-    );
-  }
-  return null;
+          <BottomWrapper>
+            <Progress>{this.state.ideas.length}</Progress>
+            <BottomText>Ideas</BottomText>
+            <SubmitButton onClick={this.handleSubmit}>Submit</SubmitButton>
+          </BottomWrapper>
+        </div>
+      );
+    }
+    return null;
   }
 }
 

--- a/client/client/src/components/Header.js
+++ b/client/client/src/components/Header.js
@@ -1,17 +1,33 @@
 import React, { Component } from "react";
+import styled from "styled-components";
 import "../css/main.css";
 import GoogleLogin from "react-google-login";
 
-class Header extends Component {
-  constructor(props) {
-    super(props);
-  }
+const Logo = styled.a`
+  position: absolute;
+  left: 50px;
+  top: 30px;
+  border: none;
+  font-family: "Work Sans", sans-serif;
+  text-transform: uppercase;
+  font-size: 16px;
+  font-weight: bold;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: normal;
+  letter-spacing: 0.8px;
+  color: #000000;
+  outline: none;
+  text-decoration: none;
+`;
 
+class Header extends Component {
   render() {
     var user_id = localStorage.getItem("ck_user_id");
     return (
       <div className="header">
-        <div className="logo_text">The creativity kernel</div>
+        <Logo href="/">The creativity kernel</Logo>
+
         {!user_id ? (
           <GoogleLogin
             clientId="747584954544-1qnj29p7cp9s9i6ind8jegnracl1tihq.apps.googleusercontent.com"
@@ -28,6 +44,7 @@ class Header extends Component {
               {localStorage.getItem("ck_user_givenName")}
             </p>
             <img
+              alt="user profile"
               className="profileImage"
               src={localStorage.getItem("ck_user_imageUrl")}
             />

--- a/client/client/src/components/Header.js
+++ b/client/client/src/components/Header.js
@@ -1,9 +1,8 @@
-import React, {Component} from 'react';
-import '../css/main.css';
-import GoogleLogin from 'react-google-login';
+import React, { Component } from "react";
+import "../css/main.css";
+import GoogleLogin from "react-google-login";
 
 class Header extends Component {
-
   constructor(props) {
     super(props);
   }
@@ -12,46 +11,51 @@ class Header extends Component {
     var user_id = localStorage.getItem("ck_user_id");
     return (
       <div className="header">
-        <div className="logo_text">
-          The creativity kernel
-        </div>
-        {!user_id ?
-        (<GoogleLogin clientId="747584954544-1qnj29p7cp9s9i6ind8jegnracl1tihq.apps.googleusercontent.com"
-          onSuccess={this.googleResponse}
-          render={renderProps => (<button className="login_button"
-            onClick={renderProps.onClick}>Log In</button>)}
-        />) :
-        (
+        <div className="logo_text">The creativity kernel</div>
+        {!user_id ? (
+          <GoogleLogin
+            clientId="747584954544-1qnj29p7cp9s9i6ind8jegnracl1tihq.apps.googleusercontent.com"
+            onSuccess={this.googleResponse}
+            render={renderProps => (
+              <button className="login_button" onClick={renderProps.onClick}>
+                Log In
+              </button>
+            )}
+          />
+        ) : (
           <div>
-            <p class="profileName">{localStorage.getItem("ck_user_givenName")}</p>
-            <img class="profileImage" src={localStorage.getItem("ck_user_imageUrl")}/>
+            <p className="profileName">
+              {localStorage.getItem("ck_user_givenName")}
+            </p>
+            <img
+              className="profileImage"
+              src={localStorage.getItem("ck_user_imageUrl")}
+            />
           </div>
         )}
-    </div>);
+      </div>
+    );
+  }
+
+  googleResponse = gresponse => {
+    console.log(gresponse.profileObj);
+    fetch("/auth/", {
+      method: "POST",
+      body: JSON.stringify(gresponse.profileObj),
+      headers: {
+        Accept: "application/json, text/plain, */*",
+        "Content-Type": "application/json",
+        Mode: "CORS"
+      }
+    })
+      .then(response => response.json())
+      .then(data => {
+        localStorage.setItem("ck_user_id", data._id);
+        localStorage.setItem("ck_user_givenName", data.givenName);
+        localStorage.setItem("ck_user_imageUrl", data.imageUrl);
+        this.forceUpdate();
+      });
   };
-
-  googleResponse = (gresponse) => {
-        console.log(gresponse.profileObj);
-        fetch('/auth/',
-          { method:'POST',
-            body:JSON.stringify(gresponse.profileObj),
-            headers: {
-              'Accept': 'application/json, text/plain, */*',
-              'Content-Type': 'application/json',
-              'Mode' : "CORS"
-            }
-          }).then(response => response.json())
-          .then(data =>
-            {
-              localStorage.setItem('ck_user_id', data._id);
-              localStorage.setItem('ck_user_givenName', data.givenName);
-              localStorage.setItem('ck_user_imageUrl', data.imageUrl);
-              this.forceUpdate();
-            }
-          );
-
-    }
-
 }
 
 export default Header;

--- a/client/client/src/components/IdeasView.js
+++ b/client/client/src/components/IdeasView.js
@@ -1,77 +1,76 @@
-import React, { Component } from 'react';
-import '../css/main.css';
-import LikeCard from './LikeCard'
-import WishCard from './WishCard'
-import styled from 'styled-components'
+import React, { Component } from "react";
+import "../css/main.css";
+import LikeCard from "./LikeCard";
+import WishCard from "./WishCard";
+import styled from "styled-components";
 
 const Wrapper = styled.div`
- margin: 50px auto ;
- max-width:800px;
- text-align:center;
+  margin: 50px auto;
+  max-width: 800px;
+  text-align: center;
 `;
 
 const Sticky = styled.textarea`
- margin:auto
- width: 160px;
- height: 160px;
- border-radius: 1px;
- border:none;
- background-color: ${props => props.wish? '#d4d3ff' : props.like ? '#ffe677' :'#fffc8d'};
- resize:none;
- outline:none;
- overflow:hidden;
- font-size: 15px;
+  margin: auto;
+  width: 160px;
+  height: 160px;
+  border-radius: 1px;
+  border: none;
+  background-color: ${props =>
+    props.wish ? "#d4d3ff" : props.like ? "#ffe677" : "#fffc8d"};
+  resize: none;
+  outline: none;
+  overflow: hidden;
+  font-size: 15px;
   font-weight: normal;
   font-style: normal;
   font-stretch: normal;
   line-height: 1.6;
   letter-spacing: 0.2px;
   color: #000000;
-  padding:10px;
-  margin:5px;
+  padding: 10px;
+  margin: 5px;
 `;
 
-const ValueWrapper = styled.div `
-  max-width:690px;
+const ValueWrapper = styled.div`
+  max-width: 690px;
   height: 70vh;
-  margin:auto;
-  overflow:scroll;
+  margin: auto;
+  overflow: scroll;
 `;
 
 const InputContainer = styled.div`
-width:60%;
-margin:auto;
-padding:1%;
-
+  width: 60%;
+  margin: auto;
+  padding: 1%;
 `;
 
 const Input = styled.textarea`
- margin:2%;
- padding:2%;
- width: 29%;
- height: 160px;
- border-radius: 1px;
-border: solid 1px #b9b9b9;
-background-color: #ffffff;
-resize:none;
-outline:none;
-overflow:hidden;
-font-size: 15px;
- font-weight: normal;
- font-style: normal;
- font-stretch: normal;
- line-height: 1.6;
- letter-spacing: 0.2px;
+  margin: 2%;
+  padding: 2%;
+  width: 29%;
+  height: 160px;
+  border-radius: 1px;
+  border: solid 1px #b9b9b9;
+  background-color: #ffffff;
+  resize: none;
+  outline: none;
+  overflow: hidden;
+  font-size: 15px;
+  font-weight: normal;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: 1.6;
+  letter-spacing: 0.2px;
 `;
 
-
 const BottomWrapper = styled.div`
-  width:100%;
+  width: 100%;
   height: 150px;
-  margin:auto;
-  position:absolute;
-  bottom:0;
-  background-color:white;
+  margin: auto;
+  position: absolute;
+  bottom: 0;
+  background-color: white;
 `;
 
 const SubmitButton = styled.button`
@@ -83,8 +82,8 @@ const SubmitButton = styled.button`
   position: absolute;
   top: 50px;
   right: 100px;
-  color:#fafafa;
-  text-transform:uppercase;
+  color: #fafafa;
+  text-transform: uppercase;
 `;
 
 const Progress = styled.p`
@@ -93,17 +92,17 @@ const Progress = styled.p`
   font-style: normal;
   font-stretch: normal;
   letter-spacing: 0.5px;
-  color: ${props => props.disabled ? '#b9b9b9' : '#000000'};
-  border: solid 3px ${props => props.disabled ? '#b9b9b9' : '#ffe74c'};
+  color: ${props => (props.disabled ? "#b9b9b9" : "#000000")};
+  border: solid 3px ${props => (props.disabled ? "#b9b9b9" : "#ffe74c")};
   width: 75px;
   height: 75px;
-  line-height:65px;
-  border-radius:100%;
-  text-align:center;
-  margin:30px;
-  margin-left:0;
-  float:left;
-  background-color: ${props => props.disabled ? '#fafafa' : 'white'};
+  line-height: 65px;
+  border-radius: 100%;
+  text-align: center;
+  margin: 30px;
+  margin-left: 0;
+  float: left;
+  background-color: ${props => (props.disabled ? "#fafafa" : "white")};
 `;
 
 const BottomText = styled.p`
@@ -114,57 +113,55 @@ const BottomText = styled.p`
   line-height: normal;
   letter-spacing: 0.2px;
   color: #000000;
-  float:left;
+  float: left;
   margin-top: 55px;
   margin-right: 70px;
-
-
 `;
 
 class IdeasView extends Component {
-
   constructor(props) {
-   super(props);
+    super(props);
 
-   this.state = {
-     data: null,
-   };
+    this.state = {
+      data: null
+    };
 
-   this.handleSubmit = this.handleSubmit.bind(this);
- }
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
 
- handleSubmit(event){
-   this.props.history.push('/project/'+this.state.data.project);
- }
- componentDidMount() {
-   fetch('/prompts/'+this.props.match.params.id)
-     .then(response => response.json())
-     .then(data => {
-       this.setState({data});
-   });
- }
+  handleSubmit(event) {
+    this.props.history.push("/project/" + this.state.data.project);
+  }
+  componentDidMount() {
+    fetch("/prompts/" + this.props.match.params.id)
+      .then(response => response.json())
+      .then(data => {
+        this.setState({ data });
+      });
+  }
 
   render() {
-    if(this.state.data != null){
-    return (
-      <div>
-        <h2 className="text_center">How might we <strong>{this.state.data.text}</strong>?</h2>
-        <ValueWrapper>
-          {this.state.data.ideas.map(function(idea, i){
-            return <Sticky>
-              {idea.content.title}
-            </Sticky>
-          })}
-        </ValueWrapper>
+    if (this.state.data != null) {
+      return (
+        <div>
+          <h2 className="text_center">
+            How might we <strong>{this.state.data.text}</strong>?
+          </h2>
+          <ValueWrapper>
+            {this.state.data.ideas.map(function(idea, i) {
+              return <Sticky>{idea.content.title}</Sticky>;
+            })}
+          </ValueWrapper>
 
-        <BottomWrapper>
-          <SubmitButton onClick={this.handleSubmit}>Back To Project</SubmitButton>
-        </BottomWrapper>
-
-      </div>
-    );
-  }
-  return null;
+          <BottomWrapper>
+            <SubmitButton onClick={this.handleSubmit}>
+              Back To Project
+            </SubmitButton>
+          </BottomWrapper>
+        </div>
+      );
+    }
+    return null;
   }
 }
 

--- a/client/client/src/components/LikeCard.js
+++ b/client/client/src/components/LikeCard.js
@@ -1,6 +1,6 @@
-import React, { Component } from 'react';
-import '../css/main.css';
-import styled from 'styled-components'
+import React, { Component } from "react";
+import "../css/main.css";
+import styled from "styled-components";
 
 const Like = styled.div`
   width: 128px;
@@ -18,24 +18,14 @@ const Like = styled.div`
 
   margin: 5px;
   padding: 10px;
-  display:inline-block;
-  overflow:scroll;
-  position:relative;
-
+  display: inline-block;
+  overflow: scroll;
+  position: relative;
 `;
 
 class LikeCard extends Component {
-
-  constructor(props) {
-   super(props);
- }
-
   render() {
-    return (
-      <Like>
-        {this.props.data}
-      </Like>
-    );
+    return <Like>{this.props.data}</Like>;
   }
 }
 

--- a/client/client/src/components/OpportunitiesInput.js
+++ b/client/client/src/components/OpportunitiesInput.js
@@ -1,65 +1,63 @@
-import React, { Component } from 'react';
-import '../css/main.css';
-import LikeCard from './LikeCard'
-import WishCard from './WishCard'
-import styled from 'styled-components'
+import React, { Component } from "react";
+import "../css/main.css";
+import LikeCard from "./LikeCard";
+import WishCard from "./WishCard";
+import styled from "styled-components";
 import { BrowserRouter as Router, Route, Link } from "react-router-dom";
 
 const Wrapper = styled.div`
- margin: 10px auto;
- width:100%;
- padding:2%;
+  margin: 10px auto;
+  width: 100%;
+  padding: 2%;
 `;
 
 const ValueContainer = styled.div`
- float:Left;
- width:25%;
- height:70vh;
- overflow:scroll;
+  float: Left;
+  width: 25%;
+  height: 70vh;
+  overflow: scroll;
 `;
 
 const PromptsContainer = styled.div`
-  float:Left;
-  width:74%;
-  height:70vh;
-  overflow:scroll;
+  float: Left;
+  width: 74%;
+  height: 70vh;
+  overflow: scroll;
   // background:yellow;
   // background: rgba(127, 127, 127, 0.5);
-	background-image: radial-gradient(black 5%, transparent 5%);
-	background-size: 20px 20px;
-  position:relative;
+  background-image: radial-gradient(black 5%, transparent 5%);
+  background-size: 20px 20px;
+  position: relative;
 `;
 
-const Prompt = styled.div `
+const Prompt = styled.div`
   border-radius: 4px;
   box-shadow: 0 2px 7px 0 rgba(0, 0, 0, 0.1);
   background-color: #ffffff;
-  padding:15px;
-  max-width:45%;
+  padding: 15px;
+  max-width: 45%;
   // position:absolute;
-  margin:5px;
-  float:left;
-
+  margin: 5px;
+  float: left;
 `;
 
 const HMW = styled.h2`
   font-size: 12px;
-  text-transform:uppercase;
+  text-transform: uppercase;
   font-weight: normal;
   font-style: normal;
   font-stretch: normal;
   line-height: normal;
   letter-spacing: 0.5px;
   color: #1e3888;
-
 `;
 
 const PromptText = styled.textarea`
-  width:100%;
-  resize:none;
-  padding:15px;
-  border-radius:10px;
-  border:solid 1px #b9b9b9;
+  width: 100%;
+  resize: none;
+  padding: 15px;
+  border-radius: 10px;
+  border: solid 1px #b9b9b9;
   font-size: 12px;
   font-weight: bold;
   font-style: normal;
@@ -68,18 +66,16 @@ const PromptText = styled.textarea`
   letter-spacing: 0.5px;
 `;
 
-
 const ValueDrop = styled.div`
-  width:100%;
-  min-height:100px;
+  width: 100%;
+  min-height: 100px;
   //background-color:#f4f4f4
-  text-align:center;
+  text-align: center;
 `;
 
 const Draggable = styled.div`
-float:left
+  float: left;
 `;
-
 
 const Sticky = styled.textarea`
  margin:auto
@@ -87,7 +83,8 @@ const Sticky = styled.textarea`
  height: 160px;
  border-radius: 1px;
  border:none;
- background-color: ${props => props.wish? '#d4d3ff' : props.like ? '#ffe677' :'#fffc8d'};
+ background-color: ${props =>
+   props.wish ? "#d4d3ff" : props.like ? "#ffe677" : "#fffc8d"};
  resize:none;
  outline:none;
  overflow:hidden;
@@ -101,19 +98,19 @@ const Sticky = styled.textarea`
   padding:10px;
 `;
 
-const ValueWrapper = styled.div `
-  max-width:690px;
+const ValueWrapper = styled.div`
+  max-width: 690px;
   height: 35vh;
-  margin:auto;
-  overflow:scroll;
+  margin: auto;
+  overflow: scroll;
 `;
 
 const BottomWrapper = styled.div`
-  width:100%;
+  width: 100%;
   height: 150px;
-  margin:auto;
-  position:absolute;
-  bottom:0;
+  margin: auto;
+  position: absolute;
+  bottom: 0;
 `;
 
 const SubmitButton = styled.button`
@@ -125,8 +122,8 @@ const SubmitButton = styled.button`
   position: absolute;
   bottom: 10px;
   right: 10px;
-  color:#fafafa;
-  text-transform:uppercase;
+  color: #fafafa;
+  text-transform: uppercase;
 `;
 
 const Progress = styled.p`
@@ -135,17 +132,17 @@ const Progress = styled.p`
   font-style: normal;
   font-stretch: normal;
   letter-spacing: 0.5px;
-  color: ${props => props.disabled ? '#b9b9b9' : '#000000'};
-  border: solid 3px ${props => props.disabled ? '#b9b9b9' : '#ffe74c'};
+  color: ${props => (props.disabled ? "#b9b9b9" : "#000000")};
+  border: solid 3px ${props => (props.disabled ? "#b9b9b9" : "#ffe74c")};
   width: 75px;
   height: 75px;
-  line-height:65px;
-  border-radius:100%;
-  text-align:center;
-  margin:30px;
-  margin-left:0;
-  float:left;
-  background-color: ${props => props.disabled ? '#fafafa' : 'white'};
+  line-height: 65px;
+  border-radius: 100%;
+  text-align: center;
+  margin: 30px;
+  margin-left: 0;
+  float: left;
+  background-color: ${props => (props.disabled ? "#fafafa" : "white")};
 `;
 
 const BottomText = styled.p`
@@ -156,100 +153,98 @@ const BottomText = styled.p`
   line-height: normal;
   letter-spacing: 0.2px;
   color: #000000;
-  float:left;
+  float: left;
   margin-top: 55px;
   margin-right: 70px;
-
-
 `;
 
 class OpportunitiesInput extends Component {
-
   constructor(props) {
-   super(props);
+    super(props);
 
-   this.state = {
-     data: null,
-     values:[],
-     prompts:[]
-   };
+    this.state = {
+      data: null,
+      values: [],
+      prompts: []
+    };
 
-   this.handleDrop = this.handleDrop.bind(this);
-   this.handleDropOnContainer = this.handleDropOnContainer.bind(this);
-   this.allowDrop = this.allowDrop.bind(this);
-   this.handleDragStart = this.handleDragStart.bind(this);
-   this.onSubmitClick = this.onSubmitClick.bind(this);
-   this.handlePromptTextChange = this.handlePromptTextChange.bind(this);
- }
+    this.handleDrop = this.handleDrop.bind(this);
+    this.handleDropOnContainer = this.handleDropOnContainer.bind(this);
+    this.allowDrop = this.allowDrop.bind(this);
+    this.handleDragStart = this.handleDragStart.bind(this);
+    this.onSubmitClick = this.onSubmitClick.bind(this);
+    this.handlePromptTextChange = this.handlePromptTextChange.bind(this);
+  }
 
- onSubmitClick(ev){
+  onSubmitClick(ev) {}
 
- }
+  handleDragStart(ev) {}
 
- handleDragStart(ev){
+  handlePromptTextChange(ev) {
+    var promptIndex = parseInt(ev.target.id);
+    this.state.prompts[promptIndex].text = ev.target.value;
+  }
 
- }
+  handleDropOnContainer(ev) {
+    ev.preventDefault();
 
- handlePromptTextChange(ev){
-   var promptIndex = parseInt(ev.target.id);
-   this.state.prompts[promptIndex].text = ev.target.value;
- }
+    var valueIndex = parseInt(ev.dataTransfer.getData("text"));
+    var promptIndex = parseInt(ev.target.id);
+    if (promptIndex < 0) {
+      promptIndex =
+        this.state.prompts.push({
+          text: "",
+          author: localStorage.getItem("ck_user_id"),
+          project: this.state.data._id,
+          values: []
+        }) - 1;
 
- handleDropOnContainer(ev){
-   ev.preventDefault();
+      this.state.prompts[promptIndex].values.push(
+        this.state.values[valueIndex]
+      );
+      this.state.values.splice(valueIndex, 1);
+      this.forceUpdate();
+    }
+  }
 
-   var valueIndex = parseInt(ev.dataTransfer.getData("text"));
-   var promptIndex = parseInt(ev.target.id);
-   if(promptIndex <0 ){
-     promptIndex = this.state.prompts.push({
-       text: '',
-       author: localStorage.getItem('ck_user_id'),
-       project: this.state.data._id,
-       values: [],
-     })-1;
+  handleDrop(ev) {
+    ev.preventDefault();
+    var valueIndex = parseInt(ev.dataTransfer.getData("text"));
+    var promptIndex = parseInt(ev.target.id);
+    if (isNaN(promptIndex)) {
+      promptIndex = parseInt(ev.target.parentElement.id);
+      if (isNaN(promptIndex)) {
+        promptIndex = parseInt(ev.target.parentElement.parentElement.id);
+      }
+    }
+    if (promptIndex > -1) {
+      this.state.prompts[promptIndex].values.push(
+        this.state.values[valueIndex]
+      );
+      this.state.values.splice(valueIndex, 1);
+      this.forceUpdate();
+    }
+  }
 
-   this.state.prompts[promptIndex].values.push(this.state.values[valueIndex]);
-   this.state.values.splice(valueIndex, 1);
-   this.forceUpdate();
- }
- }
+  allowDrop(ev) {
+    ev.preventDefault();
+  }
 
- handleDrop(ev){
-   ev.preventDefault();
-   var valueIndex = parseInt(ev.dataTransfer.getData("text"));
-   var promptIndex = parseInt(ev.target.id);
-   if(isNaN(promptIndex)){
-     promptIndex = parseInt(ev.target.parentElement.id);
-     if(isNaN(promptIndex)){
-       promptIndex = parseInt(ev.target.parentElement.parentElement.id);
-     }
-   }
-   if(promptIndex > -1 ){
-   this.state.prompts[promptIndex].values.push(this.state.values[valueIndex]);
-   this.state.values.splice(valueIndex, 1);
-   this.forceUpdate();
- }
- }
-
- allowDrop(ev) {
-  ev.preventDefault();
-}
-
-onSubmitClick(event){
-  var project_id = this.state.data._id;
-  var values = this.state.values;
-  this.state.prompts.map(function(prompt, i){
-    fetch('/prompts',
-      { method:'POST',
+  onSubmitClick(event) {
+    var project_id = this.state.data._id;
+    var values = this.state.values;
+    this.state.prompts.map(function(prompt, i) {
+      fetch("/prompts", {
+        method: "POST",
         body: JSON.stringify(prompt),
         headers: {
-          'Accept': 'application/json, text/plain, */*',
-          'Content-Type': 'application/json',
-          'Mode' : "CORS"
+          Accept: "application/json, text/plain, */*",
+          "Content-Type": "application/json",
+          Mode: "CORS"
         }
-      }).then(response => response.json())
-      .then(data =>
-        {
+      })
+        .then(response => response.json())
+        .then(data => {
           console.log(data);
 
           // fetch('/projects:'+project_id,
@@ -261,98 +256,120 @@ onSubmitClick(event){
           //       'Mode' : "CORS"
           //     }
           //   });
-        }
-      );
-  });
+        });
+    });
 
-  alert("Successfully Saved");
-  this.props.history.push('/project/'+this.state.data._id);
-
-
- }
-
- componentDidMount() {
-   console.log('/projects/'+this.props.match.params.id)
-   fetch('/projects/'+this.props.match.params.id)
-     .then(response => response.json())
-     .then(data => {
-       this.setState({data})
-       var values = [];
-       data.wishes.map(function(wishText, i){
-         values.push({"type":1, "text":wishText})
-       });
-
-       data.likes.map(function(likeText, i){
-         values.push({"type":2, "text":likeText})
-       });
-       this.setState({values});
-
-       var prompts = [];
-       data.prompts.map(function(prompt, i){
-         prompts.push(prompt);
-       });
-       // if (prompts.length < 1){
-       //   prompts.push({
-       //     text: '',
-       //     author: localStorage.getItem('ck_user_id'),
-       //     project: data._id,
-       //     values: [],
-       //   });
-       // }
-        this.setState({prompts});
-     }
-   );
- }
-  render() {
-    if(this.state.data != null){
-      var project = this.state.data;
-    return (
-      <div>
-      <Wrapper>
-        <ValueContainer>
-          {this.state.values.map(function(value, i){
-            if(value.type==1)
-              return <Draggable id={i} onDragStart={ev =>ev.dataTransfer.setData("text", ev.target.id)}draggable="true"><WishCard data={value.text} key={i} /></Draggable>;
-            return <Draggable id={i} onDragStart={ev =>ev.dataTransfer.setData("text", ev.target.id)}draggable="true"><LikeCard data={value.text} key={i} /></Draggable>;
-          })}
-        </ValueContainer>
-
-        <PromptsContainer
-          id={-1}
-          onDrop={this.handleDropOnContainer}
-          onDragOver={ev =>{
-            ev.preventDefault();
-          }}>
-          {this.state.prompts.map(function(prompt, i){
-            return <Prompt
-              id ={i}
-            onDrop={this.handleDrop}
-            onDragOver={ev =>{
-              ev.preventDefault();
-            }}>
-                <HMW> THERE IS AN OPPORTUNITY TO...</HMW>
-                <PromptText id ={i} onChange={this.handlePromptTextChange}>{prompt.text}</PromptText>
-                <ValueDrop>
-                  {prompt.values.slice(0).reverse().map(function(value, i){
-                    if(value.type==1)
-                      return <WishCard data={value.text} key={i}/>
-                    return <LikeCard data={value.text} key={i} />
-                  })}
-                </ValueDrop>
-              </Prompt>
-
-          },this)}
-
-        </PromptsContainer>
-      </Wrapper>
-        <BottomWrapper>
-          <SubmitButton onClick={this.onSubmitClick}>Save</SubmitButton>
-        </BottomWrapper>
-      </div>
-
-    );
+    alert("Successfully Saved");
+    this.props.history.push("/project/" + this.state.data._id);
   }
-  return null;
+
+  componentDidMount() {
+    console.log("/projects/" + this.props.match.params.id);
+    fetch("/projects/" + this.props.match.params.id)
+      .then(response => response.json())
+      .then(data => {
+        this.setState({ data });
+        var values = [];
+        data.wishes.map(function(wishText, i) {
+          values.push({ type: 1, text: wishText });
+        });
+
+        data.likes.map(function(likeText, i) {
+          values.push({ type: 2, text: likeText });
+        });
+        this.setState({ values });
+
+        var prompts = [];
+        data.prompts.map(function(prompt, i) {
+          prompts.push(prompt);
+        });
+        // if (prompts.length < 1){
+        //   prompts.push({
+        //     text: '',
+        //     author: localStorage.getItem('ck_user_id'),
+        //     project: data._id,
+        //     values: [],
+        //   });
+        // }
+        this.setState({ prompts });
+      });
+  }
+  render() {
+    if (this.state.data != null) {
+      var project = this.state.data;
+      return (
+        <div>
+          <Wrapper>
+            <ValueContainer>
+              {this.state.values.map(function(value, i) {
+                if (value.type == 1)
+                  return (
+                    <Draggable
+                      id={i}
+                      onDragStart={ev =>
+                        ev.dataTransfer.setData("text", ev.target.id)
+                      }
+                      draggable="true"
+                    >
+                      <WishCard data={value.text} key={i} />
+                    </Draggable>
+                  );
+                return (
+                  <Draggable
+                    id={i}
+                    onDragStart={ev =>
+                      ev.dataTransfer.setData("text", ev.target.id)
+                    }
+                    draggable="true"
+                  >
+                    <LikeCard data={value.text} key={i} />
+                  </Draggable>
+                );
+              })}
+            </ValueContainer>
+
+            <PromptsContainer
+              id={-1}
+              onDrop={this.handleDropOnContainer}
+              onDragOver={ev => {
+                ev.preventDefault();
+              }}
+            >
+              {this.state.prompts.map(function(prompt, i) {
+                return (
+                  <Prompt
+                    id={i}
+                    onDrop={this.handleDrop}
+                    onDragOver={ev => {
+                      ev.preventDefault();
+                    }}
+                  >
+                    <HMW> THERE IS AN OPPORTUNITY TO...</HMW>
+                    <PromptText id={i} onChange={this.handlePromptTextChange}>
+                      {prompt.text}
+                    </PromptText>
+                    <ValueDrop>
+                      {prompt.values
+                        .slice(0)
+                        .reverse()
+                        .map(function(value, i) {
+                          if (value.type == 1)
+                            return <WishCard data={value.text} key={i} />;
+                          return <LikeCard data={value.text} key={i} />;
+                        })}
+                    </ValueDrop>
+                  </Prompt>
+                );
+              }, this)}
+            </PromptsContainer>
+          </Wrapper>
+          <BottomWrapper>
+            <SubmitButton onClick={this.onSubmitClick}>Save</SubmitButton>
+          </BottomWrapper>
+        </div>
+      );
+    }
+    return null;
   }
 }
 

--- a/client/client/src/components/ProjectCard.js
+++ b/client/client/src/components/ProjectCard.js
@@ -1,9 +1,7 @@
-import React, { Component } from 'react';
-import '../css/main.css';
-import {withRouter} from 'react-router-dom';
-import styled from 'styled-components';
-
-
+import React, { Component } from "react";
+import "../css/main.css";
+import { withRouter } from "react-router-dom";
+import styled from "styled-components";
 
 const Card = styled.div`
       float: left;
@@ -35,7 +33,7 @@ const Card = styled.div`
         line-height: 1.6;
         letter-spacing: 0.4px;
         padding-left: 10px
-        padding-bottom:10px;
+        padding-bottom: 10px;
       }
 `;
 
@@ -43,19 +41,18 @@ const ParticipantList = styled.div`
   width: 90%;
   border-top: solid 0.5px #979797;
   bottom: 0px;
-  left:5%;
+  left: 5%;
   position: absolute;
 
-  p{
-    display:inline-block;
+  p {
+    display: inline-block;
   }
 `;
 
-const Wrapper = styled.div `
-  width:100%;
-  float:left;
-  padding:5px;
-
+const Wrapper = styled.div`
+  width: 100%;
+  float: left;
+  padding: 5px;
 `;
 
 const ProfileImage = styled.img`
@@ -64,35 +61,30 @@ const ProfileImage = styled.img`
   border-radius: 100px;
 `;
 
-const TextWrapper =styled.div `
-  marging-left:40%;
-  padding:10px;
+const TextWrapper = styled.div`
+  marging-left: 40%;
+  padding: 10px;
 `;
-
 
 class ProjectCard extends Component {
   constructor(props) {
-   super(props);
-   this.handleClick = this.handleClick.bind(this);
- }
+    super(props);
+    this.handleClick = this.handleClick.bind(this);
+  }
 
- handleClick(){
-   this.props.history.push('/project/'+this.props.data._id);
- }
+  handleClick() {
+    this.props.history.push("/project/" + this.props.data._id);
+  }
 
   render() {
     return (
       <Card onClick={this.handleClick}>
         <h2>{this.props.data.title}</h2>
         <p>{this.props.data.description}</p>
-        <ParticipantList>
-        </ParticipantList>
+        <ParticipantList />
       </Card>
     );
   }
-
 }
-
-
 
 export default withRouter(ProjectCard);

--- a/client/client/src/components/SingleProject.js
+++ b/client/client/src/components/SingleProject.js
@@ -1,11 +1,12 @@
-import React, { Component } from 'react';
-import '../css/main.css';
-import ProjectPanel from './ProjectPanel';
-import ValuesView from './ValuesView';
-import ProgressCircle from './ProgressCircle';
+import React, { Component } from "react";
+import "../css/main.css";
+import ProjectPanel from "./ProjectPanel";
+import ValuesView from "./ValuesView";
+import ProgressCircle from "./ProgressCircle";
 import { BrowserRouter as Router, Route, Link } from "react-router-dom";
-import styled from 'styled-components';
-import creativityKernel from '../CKConstants';
+import Button from "../system/Button";
+import styled from "styled-components";
+import creativityKernel from "../CKConstants";
 
 const Wrapper = styled.div`
  margin:auto
@@ -13,21 +14,20 @@ const Wrapper = styled.div`
 `;
 
 const MainWrapper = styled.div`
- margin:auto;
- max-width:700px;
+  margin: auto;
+  max-width: 700px;
 `;
 
 const Title = styled.h2`
-font-family: "Work Sans", sans-serif;
-font-size: 34px;
-font-weight: bold;
-font-style: normal;
-font-stretch: normal;
-line-height: normal;
-letter-spacing: 0.3px;
-color: #000000;
-text-transform:capitalize;
-
+  font-family: "Work Sans", sans-serif;
+  font-size: 34px;
+  font-weight: bold;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: normal;
+  letter-spacing: 0.3px;
+  color: #000000;
+  text-transform: capitalize;
 `;
 
 const Description = styled.p`
@@ -38,9 +38,8 @@ const Description = styled.p`
   line-height: 2;
   letter-spacing: 0.5px;
   color: #000000;
-  margin-top:30px;
-  margin-bottom:50px;
-
+  margin-top: 30px;
+  margin-bottom: 50px;
 `;
 
 const StartedOn = styled.p`
@@ -51,26 +50,24 @@ const StartedOn = styled.p`
   line-height: normal;
   letter-spacing: 0.4px;
   color: #5e6165;
-
 `;
 
 const SegmentHeader = styled.p`
-    border-bottom: solid 1px #1e3888;
-    /* padding:5px; */
-    /* margin:10px; */
-    font-size: 14px;
-    font-weight: 500;
-    font-style: normal;
-    font-stretch: normal;
-    line-height: normal;
-    letter-spacing: 0.1px;
-    color: #1e3888;
-
+  border-bottom: solid 1px #1e3888;
+  /* padding:5px; */
+  /* margin:10px; */
+  font-size: 14px;
+  font-weight: 500;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: normal;
+  letter-spacing: 0.1px;
+  color: #1e3888;
 `;
 
 const Module = styled.div`
   position: relative;
-  height:100px;
+  height: 100px;
 `;
 
 const Progress = styled.p`
@@ -79,17 +76,17 @@ const Progress = styled.p`
   font-style: normal;
   font-stretch: normal;
   letter-spacing: 0.5px;
-  color: ${props => props.disabled ? '#b9b9b9' : '#000000'};
-  border: solid 3px ${props => props.disabled ? '#b9b9b9' : '#ffe74c'};
+  color: ${props => (props.disabled ? "#b9b9b9" : "#000000")};
+  border: solid 3px ${props => (props.disabled ? "#b9b9b9" : "#ffe74c")};
   width: 75px;
   height: 75px;
-  line-height:65px;
-  border-radius:100%;
-  text-align:center;
+  line-height: 65px;
+  border-radius: 100%;
+  text-align: center;
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  background-color: ${props => props.disabled ? '#fafafa' : 'white'};
+  background-color: ${props => (props.disabled ? "#fafafa" : "white")};
 `;
 
 const ModuleName = styled.p`
@@ -98,7 +95,7 @@ const ModuleName = styled.p`
   font-style: normal;
   font-stretch: normal;
   letter-spacing: 0.5px;
-  color: ${props => props.disabled ? '#979797' : '#000000'};
+  color: ${props => (props.disabled ? "#979797" : "#000000")};
   position: absolute;
   top: 50%;
   left: 130px;
@@ -107,59 +104,57 @@ const ModuleName = styled.p`
 const ModuleButton = styled.button`
   font-size: 14px;
   font-weight: 500;
-  text-transform:uppercase;
+  text-transform: uppercase;
   font-style: normal;
   font-stretch: normal;
   line-height: normal;
   letter-spacing: 0.8px;
   text-align: center;
-  color: ${props => props.disabled ? '#979797' : '#fafafa'};
+  color: ${props => (props.disabled ? "#979797" : "#fafafa")};
   position: absolute;
   top: 50%;
   right: 0;
   width: 150px;
   height: 36px;
   border-radius: 4px;
-  border: solid 1px ${props => props.disabled ? '#b9b9b9;' : '#1e3888'};
-  background-color: ${props => props.disabled ? '#fafafa' : '#1e3888'};
-  outline:none;
-
+  border: solid 1px ${props => (props.disabled ? "#b9b9b9;" : "#1e3888")};
+  background-color: ${props => (props.disabled ? "#fafafa" : "#1e3888")};
+  outline: none;
 `;
 
 const LeftWrapper = styled.div`
-  float:left;
-  width:40%;
-  padding:10px;
+  float: left;
+  width: 40%;
+  padding: 10px;
 `;
 
 const ActivityHeader = styled.h2`
-font-size: 20px;
-font-weight: 500;
-font-style: normal;
-font-stretch: normal;
-line-height: normal;
-letter-spacing: 0.2px;
-color: #000000;
+  font-size: 20px;
+  font-weight: 500;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: normal;
+  letter-spacing: 0.2px;
+  color: #000000;
 `;
 
 const Activity = styled.div`
-
-margin-bottom:5px;
-position:relative;
-/* background:yellow; */
+  margin-bottom: 5px;
+  position: relative;
+  /* background:yellow; */
 `;
 
 const UserImage = styled.img`
   width: 30px;
   height: 30px;
-  border-radius:100%;
-  display:inline;
-  position:absolute;
-  top:10px;
+  border-radius: 100%;
+  display: inline;
+  position: absolute;
+  top: 10px;
 `;
 
 const UserName = styled.p`
-  display:inline;
+  display: inline;
   font-size: 14px;
   font-weight: bold;
   font-style: normal;
@@ -167,26 +162,25 @@ const UserName = styled.p`
   line-height: 50px;
   letter-spacing: 0.5px;
   color: #1e3888;
-  padding-left:40px;
+  padding-left: 40px;
 `;
 
 const Action = styled.p`
-display:inline;
-font-size: 14px;
+  display: inline;
+  font-size: 14px;
   font-weight: normal;
   font-style: normal;
   font-stretch: normal;
   line-height: normal;
   letter-spacing: 0.5px;
   color: #5e6165;
-  text-transform:lowercase;
+  text-transform: lowercase;
 `;
 
 const OpportunitiesContainer = styled.div`
-margin-left:110px;
-marging-right:20px;
-margin-top:35px;
-
+  margin-left: 110px;
+  marging-right: 20px;
+  margin-top: 35px;
 `;
 
 const Opportunity = styled.div`
@@ -206,157 +200,180 @@ const OpportunityText = styled.div`
   font-style: normal;
   font-stretch: normal;
   letter-spacing: 0.5px;
-  margin-left:2%;
-  margin-top:2%;
-  width:60%;
-
+  margin-left: 2%;
+  margin-top: 2%;
+  width: 60%;
 `;
 
 const CheatstormButton = styled.button`
-font-size: 14px;
-font-weight: 500;
-text-transform:uppercase;
-font-style: normal;
-font-stretch: normal;
-line-height: normal;
-letter-spacing: 0.8px;
-text-align: center;
-color: ${props => props.disabled ? '#979797' : '#fafafa'};
-position: absolute;
-top: 10%;
-right: 15px;
-width: 150px;
-height: 36px;
-border-radius: 4px;
-border: solid 1px ${props => props.disabled ? '#b9b9b9;' : '#1e3888'};
-background-color: ${props => props.disabled ? '#fafafa' : '#1e3888'};
-outline:none;
+  font-size: 14px;
+  font-weight: 500;
+  text-transform: uppercase;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: normal;
+  letter-spacing: 0.8px;
+  text-align: center;
+  color: ${props => (props.disabled ? "#979797" : "#fafafa")};
+  position: absolute;
+  top: 10%;
+  right: 15px;
+  width: 150px;
+  height: 36px;
+  border-radius: 4px;
+  border: solid 1px ${props => (props.disabled ? "#b9b9b9;" : "#1e3888")};
+  background-color: ${props => (props.disabled ? "#fafafa" : "#1e3888")};
+  outline: none;
 `;
 
 const ViewButton = styled.button`
-
-font-size: 14px;
-font-weight: 500;
-text-transform:uppercase;
-font-style: normal;
-font-stretch: normal;
-line-height: normal;
-letter-spacing: 0.8px;
-text-align: center;
-color: ${props => props.disabled ? '#979797' : '#fafafa'};
-position: absolute;
-bottom: 10%;
-right: 15px;
-width: 150px;
-height: 36px;
-border-radius: 4px;
-border: solid 1px ${props => props.disabled ? '#b9b9b9;' : '#1e3888'};
-background-color: ${props => props.disabled ? '#fafafa' : '#1e3888'};
-outline:none;
+  font-size: 14px;
+  font-weight: 500;
+  text-transform: uppercase;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: normal;
+  letter-spacing: 0.8px;
+  text-align: center;
+  color: ${props => (props.disabled ? "#979797" : "#fafafa")};
+  position: absolute;
+  bottom: 10%;
+  right: 15px;
+  width: 150px;
+  height: 36px;
+  border-radius: 4px;
+  border: solid 1px ${props => (props.disabled ? "#b9b9b9;" : "#1e3888")};
+  background-color: ${props => (props.disabled ? "#fafafa" : "#1e3888")};
+  outline: none;
 `;
 
-
 class SingleProject extends Component {
+  constructor(props) {
+    super(props);
 
- constructor(props) {
-  super(props);
+    this.state = {
+      data: null
+    };
 
-  this.state = {
-    data: null,
+    this.handleClickValues = this.handleClickValues.bind(this);
+    this.handleClickOpportunities = this.handleClickOpportunities.bind(this);
+    this.handleCheatstormClick = this.handleCheatstormClick.bind(this);
+    this.handleIdeasViewClick = this.handleIdeasViewClick.bind(this);
+  }
+
+  handleClickValues() {
+    this.props.history.push("/valuesinput/" + this.state.data._id);
+  }
+
+  handleClickOpportunities() {
+    this.props.history.push("/opportunitiesinput/" + this.state.data._id);
+  }
+
+  handleCheatstormClick(ev) {
+    this.props.history.push("/cheatstorm/" + ev.target.id);
+  }
+
+  handleIdeasViewClick(ev) {
+    this.props.history.push("/ideasview/" + ev.target.id);
+  }
+
+  handleVoteClick = id => {
+    if (!id) {
+      console.error("There is no Id supplied.");
+        return;
+    }
+    this.props.history.push(`/vote/${id}`);
   };
 
-  this.handleClickValues = this.handleClickValues.bind(this);
-  this.handleClickOpportunities = this.handleClickOpportunities.bind(this);
-  this.handleCheatstormClick =  this.handleCheatstormClick.bind(this);
-  this.handleIdeasViewClick =  this.handleIdeasViewClick.bind(this);
-}
-
-handleClickValues(){
-  this.props.history.push('/valuesinput/'+this.state.data._id);
-}
-
-handleClickOpportunities(){
-  this.props.history.push('/opportunitiesinput/'+this.state.data._id);
-}
-
-
-handleCheatstormClick(ev){
-  this.props.history.push('/cheatstorm/'+ev.target.id);
-}
-
-handleIdeasViewClick(ev){
-  this.props.history.push('/ideasview/'+ev.target.id);
-}
-
-
-componentDidMount() {
-  console.log('/projects/'+this.props.match.params.id)
-  fetch('/projects/'+this.props.match.params.id)
-    .then(response => response.json())
-    .then(data => this.setState({data}));
-}
+  componentDidMount() {
+    console.log("/projects/" + this.props.match.params.id);
+    fetch("/projects/" + this.props.match.params.id)
+      .then(response => response.json())
+      .then(data => this.setState({ data }));
+  }
 
   render() {
-    console.log(creativityKernel.valuesLowerLimit);
-  if(this.state.data != null){
-    var date = new Date(this.state.data.createdDate);
-    var valueCount = this.state.data.wishes.length + this.state.data.likes.length;
-    var promptCount = this.state.data.prompts.length;
+    console.log(this.state.data);
+    if (this.state.data != null) {
+      var date = new Date(this.state.data.createdDate);
+      var valueCount =
+        this.state.data.wishes.length + this.state.data.likes.length;
+      var promptCount = this.state.data.prompts.length;
 
-    return (
-      <Wrapper>
-        <MainWrapper>
-          <Title>
-            {this.state.data.title}
-          </Title>
-          <Description>
-            {this.state.data.description}
-          </Description>
-          <StartedOn>
-            Started On: {date.toLocaleString()}
-          </StartedOn>
-          <SegmentHeader>
-
-          </SegmentHeader>
-          <Module>
-            <Progress>
-              {this.state.data.wishes.length + this.state.data.likes.length}
-            </Progress>
-            <ModuleName>
-              Likes and Wishes
-            </ModuleName>
-            <ModuleButton onClick = {this.handleClickValues}>
-                ADD
-            </ModuleButton>
-          </Module>
-          <Module>
-            <Progress disabled = {valueCount < creativityKernel.valuesLowerLimit?true:false}>
-                    {this.state.data.prompts.length}
-            </Progress>
-            <ModuleName disabled = {valueCount < creativityKernel.valuesLowerLimit?true:false}>
-              Opportunities
-            </ModuleName>
-            <ModuleButton onClick = {this.handleClickOpportunities} disabled = {valueCount < creativityKernel.valuesLowerLimit?true:false}>
+      return (
+        <Wrapper>
+          <MainWrapper>
+            <Title>{this.state.data.title}</Title>
+            <Description>{this.state.data.description}</Description>
+            <StartedOn>Started On: {date.toLocaleString()}</StartedOn>
+            <SegmentHeader />
+            <Module>
+              <Progress>
+                {this.state.data.wishes.length + this.state.data.likes.length}
+              </Progress>
+              <ModuleName>Likes and Wishes</ModuleName>
+              <ModuleButton onClick={this.handleClickValues}>ADD</ModuleButton>
+            </Module>
+            <Module>
+              <Progress
+                disabled={
+                  valueCount < creativityKernel.valuesLowerLimit ? true : false
+                }
+              >
+                {this.state.data.prompts.length}
+              </Progress>
+              <ModuleName
+                disabled={
+                  valueCount < creativityKernel.valuesLowerLimit ? true : false
+                }
+              >
+                Opportunities
+              </ModuleName>
+              <ModuleButton
+                onClick={this.handleClickOpportunities}
+                disabled={
+                  valueCount < creativityKernel.valuesLowerLimit ? true : false
+                }
+              >
                 Synthesize
-            </ModuleButton>
-          </Module>
-          <OpportunitiesContainer >
-            {this.state.data.prompts.map(function(prompt, i){
-              if(prompt.text != null){
-                return <Opportunity><OpportunityText>{prompt.text}</OpportunityText>
-                  <CheatstormButton id={prompt._id}  onClick={this.handleCheatstormClick}>Cheatstorm</CheatstormButton>
-                  <ViewButton id={prompt._id}  onClick={this.handleIdeasViewClick}>View Ideas</ViewButton>
-                </Opportunity>
-              }
-            },this)
-          }
-
-          </OpportunitiesContainer>
-        </MainWrapper>
-      </Wrapper>
-    );
-  }
-  return null;
+              </ModuleButton>
+            </Module>
+            <OpportunitiesContainer>
+              {this.state.data.prompts.map(function(prompt, i) {
+                if (prompt.text != null) {
+                  return (
+                    <Opportunity key={prompt._id}>
+                      <OpportunityText>{prompt.text}</OpportunityText>
+                      <CheatstormButton
+                        id={prompt._id}
+                        onClick={this.handleCheatstormClick}
+                      >
+                        Cheatstorm
+                      </CheatstormButton>
+                      <ViewButton
+                        id={prompt._id}
+                        onClick={this.handleIdeasViewClick}
+                      >
+                        View Ideas
+                      </ViewButton>
+                      <Button
+                        onClick={() => {
+                          this.handleVoteClick(prompt._id);
+                        }}
+                      >
+                        Vote
+                      </Button>
+                    </Opportunity>
+                  );
+                }
+                return null;
+              }, this)}
+            </OpportunitiesContainer>
+          </MainWrapper>
+        </Wrapper>
+      );
+    }
+    return null;
   }
 }
 

--- a/client/client/src/components/SingleProject.js
+++ b/client/client/src/components/SingleProject.js
@@ -1,9 +1,5 @@
 import React, { Component } from "react";
 import "../css/main.css";
-import ProjectPanel from "./ProjectPanel";
-import ValuesView from "./ValuesView";
-import ProgressCircle from "./ProgressCircle";
-import { BrowserRouter as Router, Route, Link } from "react-router-dom";
 import Button from "../system/Button";
 import styled from "styled-components";
 import creativityKernel from "../CKConstants";
@@ -122,76 +118,23 @@ const ModuleButton = styled.button`
   outline: none;
 `;
 
-const LeftWrapper = styled.div`
-  float: left;
-  width: 40%;
-  padding: 10px;
-`;
-
-const ActivityHeader = styled.h2`
-  font-size: 20px;
-  font-weight: 500;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: normal;
-  letter-spacing: 0.2px;
-  color: #000000;
-`;
-
-const Activity = styled.div`
-  margin-bottom: 5px;
-  position: relative;
-  /* background:yellow; */
-`;
-
-const UserImage = styled.img`
-  width: 30px;
-  height: 30px;
-  border-radius: 100%;
-  display: inline;
-  position: absolute;
-  top: 10px;
-`;
-
-const UserName = styled.p`
-  display: inline;
-  font-size: 14px;
-  font-weight: bold;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: 50px;
-  letter-spacing: 0.5px;
-  color: #1e3888;
-  padding-left: 40px;
-`;
-
-const Action = styled.p`
-  display: inline;
-  font-size: 14px;
-  font-weight: normal;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: normal;
-  letter-spacing: 0.5px;
-  color: #5e6165;
-  text-transform: lowercase;
-`;
-
 const OpportunitiesContainer = styled.div`
   margin-left: 110px;
-  marging-right: 20px;
+  margin-right: 20px;
   margin-top: 35px;
 `;
 
 const Opportunity = styled.div`
-position:relative;
-margin:20px;
-width:100%
-box-shadow: 0 2px 7px 0 rgba(0, 0, 0, 0.1);
-border: solid 1px #1e3888;
-border-radius:5px;
-min-height:100px;
-padding:10px;
+  position: relative;
+  margin: 20px;
+  width: 100%;
+  box-shadow: 0 2px 7px 0 rgba(0, 0, 0, 0.1);
+  border: solid 1px #1e3888;
+  border-radius: 5px;
+  min-height: 100px;
+  padding: 10px;
+  display: flex;
+  justify-content: space-between;
 `;
 
 const OpportunityText = styled.div`
@@ -202,49 +145,18 @@ const OpportunityText = styled.div`
   letter-spacing: 0.5px;
   margin-left: 2%;
   margin-top: 2%;
-  width: 60%;
+  margin-right: 20px;
 `;
 
-const CheatstormButton = styled.button`
-  font-size: 14px;
-  font-weight: 500;
-  text-transform: uppercase;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: normal;
-  letter-spacing: 0.8px;
-  text-align: center;
-  color: ${props => (props.disabled ? "#979797" : "#fafafa")};
-  position: absolute;
-  top: 10%;
-  right: 15px;
-  width: 150px;
-  height: 36px;
-  border-radius: 4px;
-  border: solid 1px ${props => (props.disabled ? "#b9b9b9;" : "#1e3888")};
-  background-color: ${props => (props.disabled ? "#fafafa" : "#1e3888")};
-  outline: none;
-`;
+const OpportunityActions = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-right: 10px;
 
-const ViewButton = styled.button`
-  font-size: 14px;
-  font-weight: 500;
-  text-transform: uppercase;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: normal;
-  letter-spacing: 0.8px;
-  text-align: center;
-  color: ${props => (props.disabled ? "#979797" : "#fafafa")};
-  position: absolute;
-  bottom: 10%;
-  right: 15px;
-  width: 150px;
-  height: 36px;
-  border-radius: 4px;
-  border: solid 1px ${props => (props.disabled ? "#b9b9b9;" : "#1e3888")};
-  background-color: ${props => (props.disabled ? "#fafafa" : "#1e3888")};
-  outline: none;
+  & > button {
+    margin-top: 5px;
+    margin-bottom: 5px;
+  }
 `;
 
 class SingleProject extends Component {
@@ -280,7 +192,7 @@ class SingleProject extends Component {
   handleVoteClick = id => {
     if (!id) {
       console.error("There is no Id supplied.");
-        return;
+      return;
     }
     this.props.history.push(`/vote/${id}`);
   };
@@ -293,12 +205,10 @@ class SingleProject extends Component {
   }
 
   render() {
-    console.log(this.state.data);
     if (this.state.data != null) {
       var date = new Date(this.state.data.createdDate);
       var valueCount =
         this.state.data.wishes.length + this.state.data.likes.length;
-      var promptCount = this.state.data.prompts.length;
 
       return (
         <Wrapper>
@@ -344,25 +254,27 @@ class SingleProject extends Component {
                   return (
                     <Opportunity key={prompt._id}>
                       <OpportunityText>{prompt.text}</OpportunityText>
-                      <CheatstormButton
-                        id={prompt._id}
-                        onClick={this.handleCheatstormClick}
-                      >
-                        Cheatstorm
-                      </CheatstormButton>
-                      <ViewButton
-                        id={prompt._id}
-                        onClick={this.handleIdeasViewClick}
-                      >
-                        View Ideas
-                      </ViewButton>
-                      <Button
-                        onClick={() => {
-                          this.handleVoteClick(prompt._id);
-                        }}
-                      >
-                        Vote
-                      </Button>
+                      <OpportunityActions>
+                        <Button
+                          id={prompt._id}
+                          onClick={this.handleCheatstormClick}
+                        >
+                          Cheatstorm
+                        </Button>
+                        <Button
+                          id={prompt._id}
+                          onClick={this.handleIdeasViewClick}
+                        >
+                          View Ideas
+                        </Button>
+                        <Button
+                          onClick={() => {
+                            this.handleVoteClick(prompt._id);
+                          }}
+                        >
+                          Vote
+                        </Button>
+                      </OpportunityActions>
                     </Opportunity>
                   );
                 }

--- a/client/client/src/components/VoteView/index.js
+++ b/client/client/src/components/VoteView/index.js
@@ -1,0 +1,122 @@
+import React, { Component } from "react";
+import styled from "styled-components";
+import IdeaCard from "../../system/IdeaCard";
+import Button from "../../system/Button";
+
+// Configuration
+const max_votes = 5;
+
+/**
+ * DATA FORMATS
+ *
+ * idea: {
+ *  _id: // string
+ *  content: {
+ *    metaTags: [],
+ *    title: // string
+ *  }
+ *  created_date: // date string
+ *  prompt_id: // string
+ * }
+ *
+ * vote: {
+ *  idea_id: // string
+ *  user_id: // string
+ * }
+ */
+
+const ModuleFooter = styled.div`
+  position: absolute;
+  padding: 20px;
+  bottom: 0;
+`;
+
+export default class VoteView extends Component {
+  state = { ideas: [], votes: [] };
+
+  componentDidMount() {
+    const url = `/prompts/${this.props.match.params.id}`;
+    fetch(url)
+      .then(response => response.json())
+      .then(data => {
+        // this.setState({ data });
+        console.log(data);
+        this.processData(data);
+      });
+  }
+
+  // Helper function to process the data
+  processData(data) {
+    const votes = {};
+    // TODO process data
+    const selfId = localStorage.getItem("ck_user_id");
+
+    this.setState({
+      ideas: data.ideas,
+      text: data.text,
+      votes: votes,
+      selfVotes: []
+    });
+  }
+
+  handleOnClick(idea) {
+    let { selfVotes, votes } = this.state;
+    let voteIndex = selfVotes.findIndex(vote => vote.idea_id === idea._id);
+    const hasVoted = voteIndex >= 0;
+    const selfId = localStorage.getItem("ck_user_id");
+
+    if (!hasVoted && selfVotes.count >= max_votes) {
+      // Already at max vote, do nothing
+      return;
+    } else if (hasVoted) {
+      // Remove from self
+      selfVotes.splice(voteIndex, 1);
+      // Remove from object
+      let ideaVotes = votes[idea._id];
+      let index = ideaVotes.findIndex(vote => vote.user_id === selfId);
+      ideaVotes.splice(index, 1);
+      votes[idea._id] = ideaVotes;
+    } else {
+      const vote = {
+        idea_id: idea._id,
+        user_id: selfId
+      };
+      selfVotes.push(vote);
+      if (!votes[idea._id]) {
+        votes[idea._id] = [];
+      }
+      votes[idea._id].push(vote);
+    }
+    this.setState({ votes, selfVotes });
+
+    // TODO: Update the service
+  }
+
+  render() {
+    const { text = "", ideas = [], votes = {} } = this.state;
+    return (
+      <div>
+        <h2 className="text_center">
+          How might we <strong>{text}</strong>
+        </h2>
+        <div>
+          {ideas.map((idea, i) => {
+            let ideaVotes = votes[idea._id] || [];
+            return (
+              <IdeaCard
+                key={i}
+                onClick={() => this.handleOnClick(idea)}
+                votes={ideaVotes}
+              >
+                {idea.content.title}
+              </IdeaCard>
+            );
+          })}
+        </div>
+        <ModuleFooter>
+          Number of Votes <Button>Done</Button>
+        </ModuleFooter>
+      </div>
+    );
+  }
+}

--- a/client/client/src/components/VoteView/index.js
+++ b/client/client/src/components/VoteView/index.js
@@ -8,28 +8,55 @@ const max_votes = 5;
 
 /**
  * DATA FORMATS
- *
- *
- * idea: {
- *  _id: // string
- *  content: {
- *    metaTags: [],
- *    title: // string
- *  }
- *  created_date: // date string
- *  prompt_id: // string
- * }
- *
  * vote: {
  *  user_id: // string
  *  position: // { x, y }
  * }
  */
 
+const ContentContainer = styled.div`
+  padding-bottom: 110px;
+`;
+
+const VoteCanvas = styled.div`
+  margin: 0 auto;
+  max-width: 1200px;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
+`;
+
+const Placeholder = styled.div`
+  justify-content: center;
+  margin-top: 100px;
+  color: #9b9b9b;
+`;
+
 const ModuleFooter = styled.div`
   position: absolute;
-  padding: 20px;
+  padding: 30px 30px 40px;
   bottom: 0;
+  left: 0;
+  right: 0;
+`;
+
+const FooterContent = styled.div`
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+`;
+
+const FooterMetadata = styled.div`
+  display: flex;
+  flex: 1 0;
+  justify-content: flex-end;
+  margin-right: 30px;
+`;
+
+const FooterAction = styled.div`
+  margin-right: 10px;
 `;
 
 // TODO: refactor this out into a separate utility class
@@ -75,6 +102,24 @@ export default class VoteView extends Component {
     });
   }
 
+  renderIdeas(ideas, votes) {
+    if (ideas.length === 0) {
+      return <Placeholder>There are no ideas</Placeholder>;
+    }
+    return ideas.map((idea, i) => {
+      let ideaVotes = votes[idea._id] || [];
+      return (
+        <IdeaCard
+          key={i}
+          onClick={e => this.handleOnClick(e, idea)}
+          votes={ideaVotes}
+        >
+          {idea.content.title}
+        </IdeaCard>
+      );
+    });
+  }
+
   handleOnClick(e, idea) {
     e.preventDefault();
     const selfId = localStorage.getItem("ck_user_id");
@@ -107,7 +152,7 @@ export default class VoteView extends Component {
         .then(data => {
           this.processData(data);
         });
-    } else if (selfVotes.count >= max_votes) {
+    } else if (selfVotes.length >= max_votes) {
       // Already at max vote, do nothing
       return;
     } else {
@@ -147,22 +192,18 @@ export default class VoteView extends Component {
         <h2 className="text_center">
           How might we <strong>{text}</strong>
         </h2>
-        <div>
-          {ideas.map((idea, i) => {
-            let ideaVotes = votes[idea._id] || [];
-            return (
-              <IdeaCard
-                key={i}
-                onClick={e => this.handleOnClick(e, idea)}
-                votes={ideaVotes}
-              >
-                {idea.content.title}
-              </IdeaCard>
-            );
-          })}
-        </div>
+        <ContentContainer>
+          <VoteCanvas>{this.renderIdeas(ideas, votes)}</VoteCanvas>
+        </ContentContainer>
         <ModuleFooter>
-          Number of Votes: {max_votes - selfVotes.length} <Button>Done</Button>
+          <FooterContent>
+            <FooterMetadata>
+              Votes left: {max_votes - selfVotes.length}
+            </FooterMetadata>
+            <FooterAction>
+              <Button>Done</Button>
+            </FooterAction>
+          </FooterContent>
         </ModuleFooter>
       </div>
     );

--- a/client/client/src/components/VoteView/index.js
+++ b/client/client/src/components/VoteView/index.js
@@ -92,6 +92,21 @@ export default class VoteView extends Component {
       let index = ideaVotes.findIndex(vote => vote.user_id === selfId);
       ideaVotes.splice(index, 1);
       prompt.votes[idea._id] = ideaVotes;
+      fetch(`/prompts/${prompt._id}/ideas/${idea._id}/vote`, {
+        method: "DELETE",
+        body: JSON.stringify({
+          user_id: selfId
+        }),
+        headers: {
+          Accept: "application/json, text/plain, */*",
+          "Content-Type": "application/json",
+          Mode: "CORS"
+        }
+      })
+        .then(response => response.json())
+        .then(data => {
+          this.processData(data);
+        });
     } else if (selfVotes.count >= max_votes) {
       // Already at max vote, do nothing
       return;
@@ -106,22 +121,22 @@ export default class VoteView extends Component {
         prompt.votes[idea._id] = [];
       }
       prompt.votes[idea._id].push(vote);
+
+      fetch(`/prompts/${prompt._id}/ideas/${idea._id}/vote`, {
+        method: "PUT",
+        body: JSON.stringify(vote),
+        headers: {
+          Accept: "application/json, text/plain, */*",
+          "Content-Type": "application/json",
+          Mode: "CORS"
+        }
+      })
+        .then(response => response.json())
+        .then(data => {
+          this.processData(data);
+        });
     }
     this.setState({ prompt, selfVotes });
-
-    fetch(`/prompts/${prompt._id}`, {
-      method: "PUT",
-      body: JSON.stringify(prompt),
-      headers: {
-        Accept: "application/json, text/plain, */*",
-        "Content-Type": "application/json",
-        Mode: "CORS"
-      }
-    })
-      .then(response => response.json())
-      .then(data => {
-        // do nothing for now
-      });
   }
 
   render() {

--- a/client/client/src/components/WishCard.js
+++ b/client/client/src/components/WishCard.js
@@ -1,6 +1,6 @@
-import React, { Component } from 'react';
-import '../css/main.css';
-import styled from 'styled-components'
+import React, { Component } from "react";
+import "../css/main.css";
+import styled from "styled-components";
 
 const Wish = styled.div`
   width: 128px;
@@ -18,23 +18,13 @@ const Wish = styled.div`
 
   margin: 5px;
   padding: 10px;
-  display:inline-block;
-  overflow:scroll;
-
+  display: inline-block;
+  overflow: scroll;
 `;
 
 class WishCard extends Component {
-
-  constructor(props) {
-   super(props);
- }
-
   render() {
-    return (
-      <Wish>
-        {this.props.data}
-      </Wish>
-    );
+    return <Wish>{this.props.data}</Wish>;
   }
 }
 

--- a/client/client/src/css/main.css
+++ b/client/client/src/css/main.css
@@ -1,19 +1,19 @@
-@import url('https://fonts.googleapis.com/css?family=Work+Sans:100,200,300,400,500,600,700,800,900');
+@import url("https://fonts.googleapis.com/css?family=Work+Sans:100,200,300,400,500,600,700,800,900");
 
 * {
-    box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 h1 {
-font-family: "Work Sans", sans-serif;
-font-size: 34px;
-font-weight: normal;
-font-style: normal;
-font-stretch: normal;
-line-height: normal;
-letter-spacing: 0.3px;
-color: #000000;
-padding-top: 50px
+  font-family: "Work Sans", sans-serif;
+  font-size: 34px;
+  font-weight: normal;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: normal;
+  letter-spacing: 0.3px;
+  color: #000000;
+  padding-top: 50px;
 }
 
 h2 {
@@ -27,17 +27,17 @@ h2 {
   /* color: #1e3888; */
 }
 
-.text_center{
+.text_center {
   text-align: center;
 }
 
 /* allprojects */
 
-.AllProjects{
+.AllProjects {
   max-width: 1000px;
   margin: 10px auto;
 }
-.AllProjects h1{
+.AllProjects h1 {
   margin: 1%;
   font-size: 34px;
   font-weight: normal;
@@ -48,42 +48,41 @@ h2 {
   color: #000000;
 }
 
-.AllProjectsHeader{
+.AllProjectsHeader {
   position: relative;
 }
 
-.NewButton{
-position: absolute;
-right:1%;
-top:40px;
-width: 157px;
-height: 36px;
-border-radius: 4px;
-border: solid 1px #1e3888;
-background-color:#fafafa;
+.NewButton {
+  position: absolute;
+  right: 1%;
+  top: 40px;
+  width: 157px;
+  height: 36px;
+  border-radius: 4px;
+  border: solid 1px #1e3888;
+  background-color: #fafafa;
 
-font-size: 14px;
-font-weight: 500;
-font-style: normal;
-font-stretch: normal;
-line-height: normal;
-letter-spacing: 0.8px;
-color: #1e3888;
+  font-size: 14px;
+  font-weight: 500;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: normal;
+  letter-spacing: 0.8px;
+  color: #1e3888;
 }
 
-
-.ProjectCard{
-      float: left;
-      width: 31.3%;
-      margin: 1%;
-      padding: 10px;
-      height: 300px;
-      box-shadow: 0 2px 7px 0 rgba(0, 0, 0, 0.1);
-      border: solid 0.5px #979797;
-      position: relative;
+.ProjectCard {
+  float: left;
+  width: 31.3%;
+  margin: 1%;
+  padding: 10px;
+  height: 300px;
+  box-shadow: 0 2px 7px 0 rgba(0, 0, 0, 0.1);
+  border: solid 0.5px #979797;
+  position: relative;
 }
 
-.ProjectCard h2{
+.ProjectCard h2 {
   font-size: 18px;
   font-weight: 500;
   font-style: normal;
@@ -91,57 +90,54 @@ color: #1e3888;
   line-height: normal;
   letter-spacing: 0.2px;
   color: #1e3888;
-  padding-left: 10px
+  padding-left: 10px;
 }
 
-.ProjectCard p{
+.ProjectCard p {
   font-size: 12px;
   font-weight: normal;
   font-style: normal;
   font-stretch: normal;
   line-height: normal;
   letter-spacing: 0.4px;
-  padding-left: 10px
+  padding-left: 10px;
 }
-.UserList{
-width: 85%;
-border-top: solid 0.5px #979797;
-bottom: 15px;
-position: absolute;
+.UserList {
+  width: 85%;
+  border-top: solid 0.5px #979797;
+  bottom: 15px;
+  position: absolute;
 }
-
 
 /* single project page */
-.SingleProject{
+.SingleProject {
   /* max-width: 1000px; */
   margin: auto;
 }
-.ActivityFeed{
+.ActivityFeed {
   width: 30%;
   float: left;
 }
 
-.ProjectPanel{
+.ProjectPanel {
   width: 70%;
   float: left;
 }
 
 /* value_container */
 
-.value_container{
+.value_container {
   margin: auto;
-  marging-top:50px;
+  marging-top: 50px;
   width: 100%;
   min-height: 500px;
   background-color: #f4f4f4;
   text-align: center;
 }
 
-
-
 /* wish */
 
-.wish_card{
+.wish_card {
   width: 160px;
   height: 160px;
   box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.1);
@@ -151,10 +147,9 @@ position: absolute;
   overflow: scroll;
 }
 
-
 /* like */
 
-.like_card{
+.like_card {
   width: 160px;
   height: 160px;
   box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.1);
@@ -173,8 +168,7 @@ position: absolute;
   color: #000000;
 }
 
-
-.login_button{
+.login_button {
   position: absolute;
   right: 50px;
   top: 30px;
@@ -191,49 +185,31 @@ position: absolute;
   outline: none;
   border: none;
 }
-.login_button:hover{
+.login_button:hover {
   font-weight: bold;
 }
 
-.logo_text{
-  position: absolute;
-  left: 50px;
-  top: 30px;
-  border:none;
-  font-family: "Work Sans", sans-serif;
-  text-transform: uppercase;
-  font-size: 16px;
-  font-weight: bold;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: normal;
-  letter-spacing: 0.8px;
-  color: #000000;
-  outline: none;
-}
-
-
-.header{
+.header {
   width: 100%;
-  height:50px;
+  height: 50px;
   border-top: solid 7px #ffe74c;
 }
 
-.profileImage{
+.profileImage {
   width: 30px;
-  height:30px;
+  height: 30px;
   top: 20px;
   right: 150px;
   background-color: gray;
   border-radius: 100px;
-  position:absolute;
+  position: absolute;
 }
 
-.profileName{
+.profileName {
   position: absolute;
   right: 80px;
   top: 10px;
-  border:none;
+  border: none;
   font-family: "Work Sans", sans-serif;
   /* text-transform: uppercase; */
   font-size: 16px;

--- a/client/client/src/setupProxy.js
+++ b/client/client/src/setupProxy.js
@@ -7,8 +7,8 @@ const proxy = require("http-proxy-middleware");
 // other requests goes to the backend. At least until we eject and build.
 //
 // See where this came from: https://facebook.github.io/create-react-app/docs/proxying-api-requests-in-development
-// const url = "http://localhost:3001";
-const url = "http://18.188.32.120:3001";
+const url = "http://localhost:3001";
+//const url = "http://18.188.32.120:3001";
 const apiUrlFragments = [
   "/projects",
   "/ideas",

--- a/client/client/src/system/Button/index.js
+++ b/client/client/src/system/Button/index.js
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+
+const Button = styled.button`
+  font-size: 14px;
+  font-weight: 500;
+  text-transform: uppercase;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: normal;
+  letter-spacing: 0.8px;
+  text-align: center;
+  color: ${props => (props.disabled ? "#979797" : "#fafafa")};
+  width: 150px;
+  height: 36px;
+  border-radius: 4px;
+  border: solid 1px ${props => (props.disabled ? "#b9b9b9;" : "#1e3888")};
+  background-color: ${props => (props.disabled ? "#fafafa" : "#1e3888")};
+  outline: none;
+`;
+
+export default Button;

--- a/client/client/src/system/IdeaCard/VotingDots.js
+++ b/client/client/src/system/IdeaCard/VotingDots.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import styled from "styled-components";
 
 const Dot = styled.div`
@@ -6,8 +7,6 @@ const Dot = styled.div`
   height: 20px;
   border-radius: 50%;
   position: absolute;
-  top: ${() => Math.random() * 120}px;
-  left: ${() => Math.random() * 120}px;
   background: ${props => stringToColor(props.userId)};
 `;
 
@@ -30,9 +29,19 @@ function stringToColor(hash) {
 }
 
 class VotingDots extends React.Component {
+  static propTypes = {
+    userId: PropTypes.string.isRequired,
+    position: PropTypes.shape({
+      x: PropTypes.number.isRequired,
+      y: PropTypes.number.isRequired
+    }).isRequired
+  };
+
   render() {
-    const { userId } = this.props;
-    return <Dot userId={userId} />;
+    const { userId, position } = this.props;
+    return (
+      <Dot style={{ top: position.y, left: position.x }} userId={userId} />
+    );
   }
 }
 

--- a/client/client/src/system/IdeaCard/VotingDots.js
+++ b/client/client/src/system/IdeaCard/VotingDots.js
@@ -1,0 +1,39 @@
+import React from "react";
+import styled from "styled-components";
+
+const Dot = styled.div`
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  position: absolute;
+  top: ${() => Math.random() * 120}px;
+  left: ${() => Math.random() * 120}px;
+  background: ${props => stringToColor(props.userId)};
+`;
+
+const colors = ["#2FBC8F", "#17195B", "#84138B", "#A03381", "#F3B1EB"];
+
+function hashCode(str) {
+  return str
+    .split("")
+    .reduce(
+      (prevHash, currVal) =>
+        ((prevHash << 5) - prevHash + currVal.charCodeAt(0)) | 0,
+      0
+    );
+}
+
+function stringToColor(hash) {
+  const number = hashCode(hash);
+  const index = Math.abs(number % colors.length);
+  return colors[index];
+}
+
+class VotingDots extends React.Component {
+  render() {
+    const { userId } = this.props;
+    return <Dot userId={userId} />;
+  }
+}
+
+export default VotingDots;

--- a/client/client/src/system/IdeaCard/index.js
+++ b/client/client/src/system/IdeaCard/index.js
@@ -13,7 +13,7 @@ const Sticky = styled.div`
     props.wish ? "#d4d3ff" : props.like ? "#ffe677" : "#fffc8d"};
   resize: none;
   outline: none;
-  overflow: hidden;
+  overflow: visible;
   font-size: 15px;
   font-weight: normal;
   font-style: normal;
@@ -24,10 +24,14 @@ const Sticky = styled.div`
   padding: 10px;
   margin: 5px;
   position: relative;
+  flex: 0 160px;
+  transition: all 0.1s;
+  cursor: default;
+  user-select: none;
 
   &:hover {
-    box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);
-    margin-top: -3px;
+    box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.15);
+    margin-top: 4px;
   }
 `;
 
@@ -45,7 +49,7 @@ class IdeaCard extends React.Component {
         ))}
         {children}
       </Sticky>
-    );  
+    );
   }
 }
 

--- a/client/client/src/system/IdeaCard/index.js
+++ b/client/client/src/system/IdeaCard/index.js
@@ -40,12 +40,12 @@ class IdeaCard extends React.Component {
     const { children, votes, ...props } = this.props;
     return (
       <Sticky {...props}>
-        {votes.map(vote => (
-          <VotingDots userId={vote.user_id} />
+        {votes.map((vote, i) => (
+          <VotingDots key={i} userId={vote.user_id} position={vote.position} />
         ))}
         {children}
       </Sticky>
-    );
+    );  
   }
 }
 

--- a/client/client/src/system/IdeaCard/index.js
+++ b/client/client/src/system/IdeaCard/index.js
@@ -1,0 +1,52 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import VotingDots from "./VotingDots";
+
+const Sticky = styled.div`
+  margin: auto;
+  width: 160px;
+  height: 160px;
+  border-radius: 1px;
+  border: none;
+  background-color: ${props =>
+    props.wish ? "#d4d3ff" : props.like ? "#ffe677" : "#fffc8d"};
+  resize: none;
+  outline: none;
+  overflow: hidden;
+  font-size: 15px;
+  font-weight: normal;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: 1.6;
+  letter-spacing: 0.2px;
+  color: #000000;
+  padding: 10px;
+  margin: 5px;
+  position: relative;
+
+  &:hover {
+    box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);
+    margin-top: -3px;
+  }
+`;
+
+class IdeaCard extends React.Component {
+  static propTypes = {
+    votes: PropTypes.array.isRequired
+  };
+
+  render() {
+    const { children, votes, ...props } = this.props;
+    return (
+      <Sticky {...props}>
+        {votes.map(vote => (
+          <VotingDots userId={vote.user_id} />
+        ))}
+        {children}
+      </Sticky>
+    );
+  }
+}
+
+export default IdeaCard;


### PR DESCRIPTION
This change introduces the voting module.

This is rather straightforward. This changeset introduces the voting module. The voting module is currently accessible when the user creates a prompt when they synthesize ideas. Clicking on the voting button brings the user to the voting module.

The voting module is also simple. Clicking on one of the ideas will add the current users vote onto it. The same user clicking on an idea that she has voted on before will remove the vote from it. It's rudimentary right now and can benefit from more explicit instructions, but this is workable for now.

This change also introduces two APIs to the server in the form of `prompts/:promptId/ideas/:ideaId/vote` using `PUT` and `DELETE` verbs. This will add and remove votes from specific ideas under specific votes. There is no true concurrency support, but this can support some crude form of simultaneous voting as the vote action is partitioned by user Id. Because the APIs above return the entire prompt object, whenever the user takes an action, any changes on the service will propagate down to the client side, so it'll work-ish. However, this definitely **does not** support multiple browser sessions with the same User Id voting. There's no explicit concurrency support.
